### PR TITLE
Add build GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - dev
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Build VirtualBox OVF image
       uses: nick-invision/retry@v2
+      env:
+        GITHUB_PULL_REQUEST: ${{ github.event.number }}
       with:
         timeout_minutes: 30
         max_attempts: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: build
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Packer cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/packer
+        key: ${{ runner.os }}-packer
+
+    - name: Build VirtualBox OVF image
+      uses: nick-invision/retry@v2
+      with:
+        timeout_minutes: 30
+        max_attempts: 5
+        command: ./build-appliance virtualbox
+
+    - name: Get build_name from OVF file
+      run: echo "build_name=$(sh -c "find . -name '*.ovf' | xargs basename -s '.ovf'")" >> $GITHUB_ENV
+      working-directory: ./output-virtualbox
+
+    - name: Change virtual hardware version
+      run: sed -i '' 's/virtualbox-2.2/vmx-13/' ${{ env.build_name }}.ovf
+      working-directory: ./output-virtualbox
+
+    - name: Create OVA manifest
+      run: openssl sha256 *.ovf *.vmdk > ${{ env.build_name }}.mf
+      working-directory: ./output-virtualbox
+
+    - name: Package OVA image
+      run: tar -cvf ../${{ env.build_name }}.ova --format=ustar ${{ env.build_name }}{.ovf,-disk001.vmdk,.mf}
+      working-directory: ./output-virtualbox
+
+    - name: Upload OVA to Azure Storage
+      run: |
+        az cloud set --name AzureUSGovernment
+        az storage blob upload --file ${{ env.build_name }}.ova \
+                               --container-name ova \
+                               --name appliance/${{ env.build_name }}.ova \
+                               --connection-string "${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}" \
+                               --no-progress

--- a/build-appliance
+++ b/build-appliance
@@ -23,6 +23,8 @@ fi
 
 if [ -n "$VERSION_TAG" ]; then
     BUILD_VERSION=$VERSION_TAG
+elif [ -n "$GITHUB_PULL_REQUEST" ]; then
+    BUILD_VERSION=PR$GITHUB_PULL_REQUEST-$GIT_HASH
 elif [ -n "$GIT_HASH" ]; then
     BUILD_VERSION=$GIT_BRANCH-$GIT_HASH
 else

--- a/foundry-appliance.pkr.hcl
+++ b/foundry-appliance.pkr.hcl
@@ -85,6 +85,7 @@ build {
   provisioner "shell" {
     execute_command   = "echo '${var.ssh_password}' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
     expect_disconnect = true
+    environment_vars  = [ "DEBIAN_FRONTEND=noninteractive" ]
     inline            = [
       "echo '${var.appliance_version}' > /etc/appliance_version",
       "swapoff -a",
@@ -125,6 +126,7 @@ build {
 
   provisioner "shell" {
     inline = [
+      "sleep 10",
       "ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -N ''",
       "microk8s status --wait-ready",
       "microk8s config -l > ~/.kube/config",

--- a/foundry/certs/generate-certs.sh
+++ b/foundry/certs/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 # 
 # Copyright 2021 Carnegie Mellon University.
 # Released under a BSD (SEI)-style license, please see LICENSE.md in the

--- a/foundry/setup-foundry
+++ b/foundry/setup-foundry
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 # 
 # Copyright 2021 Carnegie Mellon University.
 # Released under a BSD (SEI)-style license, please see LICENSE.md in the
@@ -89,7 +89,7 @@ API_KEY=$(curl -X POST --silent \
 
 sed -i -r "s/(Core__GameEngineClientSecret:).*/\1 $API_KEY/" gameboard.values.yaml 
 
-helm install --wait -f gameboard.values.yaml gameboard sei/gametracker
+helm install --wait -f gameboard.values.yaml gameboard sei/gameboard
 kubectl apply -f console-ingress.yaml
 
 # Add administrator user to Gameboard


### PR DESCRIPTION
- Remove Bash command echo from `setup-foundry` and `generate-certs.sh`
- Rewrite virtual hardware version to vmx-13 for compatibility with
  VMware
- Add retry for OVA build step
- OVA output uploads to Azure Storage
- Change Gameboard deployment to use correct chart (sei/gameboard)
- Inject sleep to fix potential race condition after initial provisioner
  reboot
- Add environment var to silence apt error messages due to
  non-interactive session