### PR TITLE
Fix multipathd errors

### DIFF
--- a/foundry/dnsmasq.conf
+++ b/foundry/dnsmasq.conf
@@ -1,3 +1,0 @@
-bind-dynamic
-listen-address=10.0.1.1
-interface-name=foundry.local,eth0

--- a/foundry/expand-volume
+++ b/foundry/expand-volume
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2022 Carnegie Mellon University.
+# Released under a BSD (SEI)-style license, please see LICENSE.md in the
+# project root or contact permission@sei.cmu.edu for full terms.
+#
+# Expand LVM logical volume and underlying ext4 filesystem
+
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+VOLUME=/dev/ubuntu-vg/ubuntu-lv
+
+lvextend -l +100%FREE $VOLUME
+resize2fs $VOLUME

--- a/foundry/setup-esxi
+++ b/foundry/setup-esxi
@@ -26,7 +26,7 @@ TOPOMOJO_ACCESS_TOKEN=$(curl --silent --request POST \
                              --data client_secret=foundry \
                              --data username=administrator@foundry.local \
                              --data password=foundry | jq -r '.access_token')
-                            
+
 
 if [[ ! $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo -e "\nUsage: $0 <esxi ip address>\n"
@@ -61,7 +61,7 @@ ssh $ESXI_USER@$ESXI_HOSTNAME << EOF
     cp $ESXI_CERTDIR/rui.crt $ESXI_CERTDIR/rui.crt.orig
   fi
   echo "$RUI_CRT" > $ESXI_CERTDIR/rui.crt
-  
+
   if [ ! -f "$ESXI_CERTDIR/rui.key.orig" ]; then
     cp $ESXI_CERTDIR/rui.key $ESXI_CERTDIR/rui.key.orig
   fi

--- a/install/stage1
+++ b/install/stage1
@@ -9,6 +9,9 @@
 
 echo "$APPLIANCE_VERSION" > /etc/appliance_version
 
+# Expand LVM volume to use full drive capacity
+~/foundry/expand-volume
+
 # Disable swap for Kubernetes
 swapoff -a
 sed -i -r 's/(\/swap\.img.*)/#\1/' /etc/fstab

--- a/install/stage1
+++ b/install/stage1
@@ -17,6 +17,21 @@ sed -i -r 's/(\/swap\.img.*)/#\1/' /etc/fstab
 apt-get update
 apt-get full-upgrade -y
 
+# Stop multipathd errors in syslog
+cat <<EOF | sudo tee -a /etc/multipath.conf
+blacklist {
+  device {
+    vendor "VBOX"
+    product "HARDDISK"
+  }
+  device {
+    vendor "VMware"
+    product "Virtual disk"
+  }
+}
+EOF
+systemctl restart multipathd
+
 # Change resolver to dnsmasq and install other needed packages
 systemctl disable --now systemd-resolved
 rm -f /etc/resolv.conf

--- a/install/stage1
+++ b/install/stage1
@@ -18,7 +18,7 @@ apt-get update
 apt-get full-upgrade -y
 
 # Stop multipathd errors in syslog
-cat <<EOF | sudo tee -a /etc/multipath.conf
+cat <<EOF >> /etc/multipath.conf
 blacklist {
   device {
     vendor "VBOX"
@@ -32,15 +32,18 @@ blacklist {
 EOF
 systemctl restart multipathd
 
-# Change resolver to dnsmasq and install other needed packages
-systemctl disable --now systemd-resolved
-rm -f /etc/resolv.conf
-echo 'nameserver 8.8.8.8' > /etc/resolv.conf
+# Add dnsmasq resolver other needed packages
 apt-get install -y dnsmasq avahi-daemon jq nfs-common sshpass
-mv ~/foundry/dnsmasq.conf /etc/dnsmasq.d/foundry.conf
-chown root:root /etc/dnsmasq.d/foundry.conf
+
+cat <<EOF > /etc/dnsmasq.d/foundry.conf
+server=8.8.8.8
+no-resolv
+bind-interfaces
+listen-address=10.0.1.1
+interface-name=foundry.local,eth0
+EOF
+
 systemctl restart dnsmasq
-sed -i -r 's/(use-ipv6=).*/\1no/' /etc/avahi/avahi-daemon.conf
 
 # Install MicroK8s
 snap install microk8s --classic --channel=1.23/stable
@@ -49,6 +52,7 @@ microk8s enable dns storage ingress metrics-server
 usermod -a -G microk8s $SSH_USERNAME
 chown -f -R $SSH_USERNAME:$SSH_USERNAME ~/.kube
 sed -i '/^DNS\.5.*/a DNS.6 = foundry.local' /var/snap/microk8s/current/certs/csr.conf.template
+
 cat <<EOF > /etc/netplan/01-host-access.yaml
 # Add loopback address for pods to talk to host
 network:
@@ -61,6 +65,7 @@ network:
         - 10.0.1.1/32:
             label: lo:host-access
 EOF
+
 netplan apply
 
 # Install kubectl and Helm clients


### PR DESCRIPTION
This fixes repeated log messages appearing in syslog from `multipathd`:

```syslog
Feb  8 12:17:15 foundry multipathd[583]: sda: add missing path
Feb  8 12:17:15 foundry multipathd[583]: sda: failed to get udev uid: Invalid argument
Feb  8 12:17:15 foundry multipathd[583]: sda: failed to get sysfs uid: Invalid argument
Feb  8 12:17:15 foundry multipathd[583]: sda: failed to get sgio uid: No such file or directory
```

One option was to [modify the .vmx file](https://askubuntu.com/a/1249890) and include disk UUID info for the VM. But that seemed like a heavier lift given the VMware and VirtualBox build processes. Instead, this PR [edits multipathd.conf to ignore those devices](https://sleeplessbeastie.eu/2021/01/06/how-to-fix-multipath-daemon-error-about-missing-path-when-using-virtualbox/).

### Other Changes

- Restores systemd-resolved and limits dnsmasq to listen on the host-access loopback address (10.0.1.1).
- Adds `foundry/expand-volume` script to use the primary drive's full capacity and runs this script during build.