### PR TITLE
Lower cfssl log output during generate-certs.sh

### DIFF
--- a/foundry/certs/generate-certs.sh
+++ b/foundry/certs/generate-certs.sh
@@ -3,16 +3,19 @@
 # Copyright 2022 Carnegie Mellon University.
 # Released under a BSD (SEI)-style license, please see LICENSE.md in the
 # project root or contact permission@sei.cmu.edu for full terms.
+#
+# ./generate-certs.sh <gencert arguments>
 
+ARGS=$*
 
 # Change to the current directory
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Generate root, intermediate and host certificates/keys
-cfssl gencert -initca root-ca.json | cfssljson -bare root-ca
-cfssl gencert -ca root-ca.pem -ca-key root-ca-key.pem -config config.json \
+cfssl gencert $ARGS -initca root-ca.json | cfssljson -bare root-ca
+cfssl gencert $ARGS -ca root-ca.pem -ca-key root-ca-key.pem -config config.json \
               -profile intca int-ca.json | cfssljson -bare int-ca
-cfssl gencert -ca int-ca.pem -ca-key int-ca-key.pem -config config.json \
+cfssl gencert $ARGS -ca int-ca.pem -ca-key int-ca-key.pem -config config.json \
               -profile server host.json | cfssljson -bare host
 
 # Create pkcs12 host bundle for identity signing key

--- a/install/stage2
+++ b/install/stage2
@@ -10,11 +10,11 @@
 # Generate SSH key
 ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -N ''
 
-# Pause for 10 seconds to avoid MicroK8s permissions error
-sleep 10
+# Sleep to avoid MicroK8s permissions error
+sleep 20
 microk8s status --wait-ready
 microk8s config -l > ~/.kube/config
 chmod 600 ~/.kube/config
 
 # Generate CA and host certificates
-~/foundry/certs/generate-certs.sh
+~/foundry/certs/generate-certs.sh -loglevel 3


### PR DESCRIPTION
Limit log output to errors when generating certificates during the build.