### PR TITLE
Change Git default branch to main

### DIFF
--- a/foundry/gitea.values.yaml
+++ b/foundry/gitea.values.yaml
@@ -101,6 +101,8 @@ gitea:
       ROOT_URL: https://foundry.local/gitea/
     security:
       PASSWORD_COMPLEXITY: "off"
+    repository:
+      DEFAULT_BRANCH: main
 
   podAnnotations: {}
 

--- a/foundry/setup-foundry
+++ b/foundry/setup-foundry
@@ -44,6 +44,7 @@ ed -s topomojo.values.yaml <<< $'/cacert.crt:/s/\"\"/|-/\n/cacert.crt:/r !sed "s
 cp certs/root-ca.pem web/root-ca.crt
 
 # Install Gitea
+git config --global init.defaultBranch main
 helm repo add gitea https://dl.gitea.io/charts/
 helm install -f gitea.values.yaml gitea gitea/gitea
 timeout 5m bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://foundry.local/gitea)" != "200" ]]; do sleep 5; done' || false

--- a/foundry/setup-gitea
+++ b/foundry/setup-gitea
@@ -29,13 +29,13 @@ curl "${CURL_OPTS[@]}" \
 EOF
 
 # Create repo
-# for repo in $(find $DOCS_DIR -maxdepth 1 -mindepth 1 -type d -printf '%P\n'); do
 curl "${CURL_OPTS[@]}" \
     --request POST "https://foundry.local/gitea/api/v1/orgs/foundry/repos?access_token=$USER_TOKEN" \
     --data @- <<EOF
 {
   "name": "web",
-  "private": false
+  "private": false,
+  "default_branch": "main"
 }
 EOF
 

--- a/install/stage1
+++ b/install/stage1
@@ -17,6 +17,7 @@ swapoff -a
 sed -i -r 's/(\/swap\.img.*)/#\1/' /etc/fstab
 
 # Upgrade existing Ubuntu packages
+sudo add-apt-repository ppa:git-core/ppa -y
 apt-get update
 apt-get full-upgrade -y
 


### PR DESCRIPTION
Changes the default branch name for two Git repos on the appliance:
    - `~/foundry/web` (also on Gitea)
    - `~/foundry`

Adds the Git PPA since the Ubuntu 20.04 version does not support `init.defaultBranch`.