### PR TITLE
TopoMojo v2.0.9 upgrade

### DIFF
--- a/foundry/topomojo/topomojo.values.yaml
+++ b/foundry/topomojo/topomojo.values.yaml
@@ -9,7 +9,7 @@ topomojo-api:
     repository: cmusei/topomojo-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.0.7"
+    tag: "2.0.9"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -166,7 +166,7 @@ topomojo-ui:
     repository: cmusei/topomojo-ui
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.0.7"
+    tag: "2.0.9"
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
Upgrade to [TopoMojo v2.0.9](https://github.com/cmu-sei/TopoMojo/releases/tag/2.0.9). Changes include:

- New TopoMojo Observer role
- Network fixes for VMware SDDC environments.