### PR TITLE
Fix pgAdmin pgpass.conf ownership

### DIFF
--- a/foundry/common/pgadmin4.values.yaml
+++ b/foundry/common/pgadmin4.values.yaml
@@ -8,7 +8,7 @@ image:
   registry: docker.io
   repository: dpage/pgadmin4
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "6.7"
   pullPolicy: IfNotPresent
 
 ## Deployment annotations
@@ -228,11 +228,11 @@ VolumePermissions:
 ##
 extraInitContainers: |
   - name: prepare-pgpass
-    image: "dpage/pgadmin4:latest"
+    image: "dpage/pgadmin4:6.7"
     command:
       - "sh"
       - "-c"
-      - "cp /pgpass.conf /var/lib/pgadmin/pgpass.conf && chown pgadmin:pgadmin /var/lib/pgadmin/pgpass.conf && chmod 600 /var/lib/pgadmin/pgpass.conf"
+      - "cp /pgpass.conf /var/lib/pgadmin/pgpass.conf && chown pgadmin:root /var/lib/pgadmin/pgpass.conf && chmod 600 /var/lib/pgadmin/pgpass.conf"
     volumeMounts:
       - name: pgadmin-data
         mountPath: /var/lib/pgadmin


### PR DESCRIPTION
Ownership of `/var/lib/pgadmin` in the pgAdmin Docker image changed with [this commit](https://github.com/postgres/pgadmin4/commit/e7dc6df7230c9ccc74bf9853fb614407b861a42a). The appliance deployment of pgAdmin places `pgpass.conf` in that directory with credentials for the database. The ownership workaround is patterned after this fix:

https://github.com/rowanruseler/helm-charts/issues/72#issuecomment-1002300143

Also, this commit pins pgAdmin to the latest Helm chart release image (`dpage/pgadmin4:6.7`).