### PR TITLE
Upgrade to Ubuntu 22.04 LTS

### DIFF
--- a/foundry-appliance.pkr.hcl
+++ b/foundry-appliance.pkr.hcl
@@ -89,7 +89,6 @@ build {
 
   provisioner "shell" {
     execute_command   = "echo '${var.ssh_password}' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
-    expect_disconnect = true
     environment_vars  = [
       "DEBIAN_FRONTEND=noninteractive",
       "APPLIANCE_VERSION=${var.appliance_version}",

--- a/foundry/foundry-banner
+++ b/foundry/foundry-banner
@@ -10,7 +10,7 @@ _______  _____   _____         _____ _______ __   _ _______ _______
 |     | |       |       |_____ __|__ |     | |  \_| |_____  |______
 
 
-Welcome to Foundry Appliance $(cat /etc/appliance_version)
+Welcome to Foundry Appliance $(cat /etc/appliance_version) ($(lsb_release -ds))
 
 Visit https://foundry.local to get started.
 EOF

--- a/http/user-data
+++ b/http/user-data
@@ -7,14 +7,5 @@ autoinstall:
     hostname: foundry
     username: foundry
     password: '$6$afOovK8m0QFt$WXfiPN3SCDetMwzHtZaMFjooafE3X55Mo.R34.za8u0YRm/dnJm4JmzBV9kWQl5w4YFsjwuRpwznmGmKYaUdq/'
-  network:
-    network:
-      version: 2
-      ethernets:
-        eth0:
-          dhcp4: true
-          dhcp-identifier: mac
   ssh:
     install-server: true
-  late-commands:
-    - sed -i 's/^#*\(send dhcp-client-identifier\).*$/\1 = hardware;/' /target/etc/dhcp/dhclient.conf

--- a/install/stage1
+++ b/install/stage1
@@ -17,7 +17,6 @@ swapoff -a
 sed -i -r 's/(\/swap\.img.*)/#\1/' /etc/fstab
 
 # Add new repositories and upgrade existing Ubuntu packages
-sudo add-apt-repository ppa:git-core/ppa -y
 curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
 echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
@@ -37,8 +36,6 @@ systemctl restart multipathd
 PRIMARY_INTERFACE=$(ip -o -4 route show to default | awk '{print $5}')
 mkdir /etc/dnsmasq.d
 cat <<EOF > /etc/dnsmasq.d/foundry.conf
-server=8.8.8.8
-no-resolv
 bind-interfaces
 listen-address=10.0.1.1
 interface-name=foundry.local,$PRIMARY_INTERFACE

--- a/install/stage1
+++ b/install/stage1
@@ -34,6 +34,16 @@ EOF
 systemctl restart multipathd
 
 # Add dnsmasq resolver and other required packages
+PRIMARY_INTERFACE=$(ip -o -4 route show to default | awk '{print $5}')
+mkdir /etc/dnsmasq.d
+cat <<EOF > /etc/dnsmasq.d/foundry.conf
+server=8.8.8.8
+no-resolv
+bind-interfaces
+listen-address=10.0.1.1
+interface-name=foundry.local,$PRIMARY_INTERFACE
+EOF
+
 cat <<EOF > /etc/netplan/01-host-access.yaml
 # Add loopback address for pods to use dnsmasq as upstream resolver
 network:
@@ -48,15 +58,6 @@ network:
 EOF
 netplan apply
 
-mkdir /etc/dnsmasq.d
-cat <<EOF > /etc/dnsmasq.d/foundry.conf
-server=8.8.8.8
-no-resolv
-bind-interfaces
-listen-address=10.0.1.1
-interface-name=foundry.local,eth0
-EOF
-
 apt-get install -y dnsmasq avahi-daemon jq nfs-common sshpass kubectl helm
 
 # Install k3s
@@ -69,8 +70,8 @@ sed -i 's/default/foundry/g' /home/$SSH_USERNAME/.kube/config
 chown $SSH_USERNAME:$SSH_USERNAME /home/$SSH_USERNAME/.kube/config
 
 # Install CFSSL for certificate generation
-curl -sLo /usr/local/bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64
-curl -sLo /usr/local/bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64
+curl -sLo /usr/local/bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssl_1.6.1_linux_amd64
+curl -sLo /usr/local/bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.6.1/cfssljson_1.6.1_linux_amd64
 chmod +x /usr/local/bin/cfssl*
 
 # Install k-alias Kubernetes helper scripts
@@ -85,8 +86,3 @@ cp /home/foundry/$SSH_USERNAME/foundry-banner /etc/update-motd.d/05-foundry-bann
 rm /home/foundry/$SSH_USERNAME/foundry-banner
 sed -i "s/{version}/$APPLIANCE_VERSION/" ~/mkdocs/docs/index.md
 echo -e "Foundry Appliance $APPLIANCE_VERSION \\\n \l \n" > /etc/issue
-
-# Enable quiet boot and reboot for changes to take effect
-sed -i -r 's/(GRUB_CMDLINE_LINUX_DEFAULT=).*/\1"quiet net.ifnames=0 biosdevname=0"/' /etc/default/grub
-update-grub
-reboot

--- a/install/stage3
+++ b/install/stage3
@@ -13,3 +13,6 @@ update-ca-certificates
 
 # Restart mDNS daemon to avoid conflict with other hosts
 systemctl restart avahi-daemon
+
+# Delete Ubuntu machine ID for proper DHCP operation on deploy
+echo -n > /etc/machine-id

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -46,15 +46,16 @@ variable "vsphere_network" {
 
 locals {
   boot_command     = [
-    "<wait><enter><enter><f6><esc><wait> ",
-    "net.ifnames=0 biosdevname=0 autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/",
-    "<enter>",
-    "<wait10><wait10><wait10><wait10><wait10><wait10>"
+  "e<wait>",
+  "<down><down><down>",
+  "<end><bs><bs><bs><bs><wait>",
+  "autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ---<wait>",
+  "<f10><wait>"
   ]
   cpus             = 2
   disk_size        = 30000
-  iso_url          = "https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso"
-  iso_checksum     = "sha256:28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad"
+  iso_url          = "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso"
+  iso_checksum     = "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f"
   memory           = 4096
   shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"
 }


### PR DESCRIPTION
- Use predictable network interface names (ens160,…) instead of legacy eth0
- Remove `quiet` kernel parameter for better boot visibility
- Change DHCP identifier to Ubuntu machine ID
- Remove reboot at the end of stage1 install script
- Upgrade to CFSSL v1.6.1