### PR TITLE
Pin K3s to specific version: v1.23.6

### DIFF
--- a/install/stage1
+++ b/install/stage1
@@ -60,7 +60,7 @@ apt-get install -y dnsmasq avahi-daemon jq nfs-common sshpass kubectl helm
 # Install k3s
 mkdir -p /etc/rancher/k3s
 echo "nameserver 10.0.1.1" >> /etc/rancher/k3s/resolv.conf
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=v1.23 INSTALL_K3S_EXEC="--disable traefik --disable servicelb --resolv-conf /etc/rancher/k3s/resolv.conf" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.23.6+k3s1" INSTALL_K3S_EXEC="--disable traefik --disable servicelb --resolv-conf /etc/rancher/k3s/resolv.conf" sh -
 sudo -u $SSH_USERNAME mkdir ~/.kube
 cp /etc/rancher/k3s/k3s.yaml /home/$SSH_USERNAME/.kube/config
 sed -i 's/default/foundry/g' /home/$SSH_USERNAME/.kube/config


### PR DESCRIPTION
CI builds with k3s v1.23.7 are failing with `error dialing backend: EOF` during Gameboard deployment:

```
    virtualbox-iso.foundry-appliance: NAME: gameboard
    virtualbox-iso.foundry-appliance: LAST DEPLOYED: Mon Jun 13 11:16:56 2022
    virtualbox-iso.foundry-appliance: NAMESPACE: topomojo
    virtualbox-iso.foundry-appliance: STATUS: deployed
    virtualbox-iso.foundry-appliance: REVISION: 1
    virtualbox-iso.foundry-appliance: NOTES:
    virtualbox-iso.foundry-appliance: Course charted for gameboard.
==> virtualbox-iso.foundry-appliance: Error from server: error dialing backend: EOF
```

This could be related to similar issues in the K3s project:
- https://github.com/k3s-io/k3s/issues/5637
- https://github.com/k3s-io/k3s/issues/5633

This PR pins K3s to the latest stable version, v1.23.6.