### PR TITLE
Fix predictable network interface name on first boot

### DIFF
--- a/foundry/configure-nic
+++ b/foundry/configure-nic
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2022 Carnegie Mellon University.
+# Released under a BSD (SEI)-style license, please see LICENSE.md in the
+# project root or contact permission@sei.cmu.edu for full terms.
+#
+# Configure netplan and dnsmasq to use first Ethernet interface
+
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+PRIMARY_ETH=$(find /sys/class/net/en* -type l -printf "%f\n" | head -n 1)
+DNSMASQ_CONF=/etc/dnsmasq.d/foundry.conf
+NETPLAN_CONF=/etc/netplan/00-installer-config.yaml
+FLAG=/etc/.configure-nic
+
+if [ ! -f "$FLAG" ]; then
+    sed -i -r "s/en.*:/$PRIMARY_ETH:/" $NETPLAN_CONF
+    netplan apply
+    sed -i -r "s/(foundry.local,).*/\1$PRIMARY_ETH/" $DNSMASQ_CONF
+    systemctl restart dnsmasq
+    date > $FLAG
+    echo "$PRIMARY_ETH configured as primary Ethernet interface."
+else
+    echo "Configuration skipped. Delete $FLAG to reconfigure the primary interface."
+fi

--- a/install/stage1
+++ b/install/stage1
@@ -41,7 +41,7 @@ listen-address=10.0.1.1
 interface-name=foundry.local,$PRIMARY_INTERFACE
 EOF
 
-cat <<EOF > /etc/netplan/01-host-access.yaml
+cat <<EOF > /etc/netplan/01-loopback.yaml
 # Add loopback address for pods to use dnsmasq as upstream resolver
 network:
   version: 2
@@ -50,8 +50,11 @@ network:
       match:
         name: lo
       addresses:
+        - 127.0.0.1/8:
+            label: lo
         - 10.0.1.1/32:
             label: lo:host-access
+        - ::1/128
 EOF
 netplan apply
 
@@ -83,3 +86,20 @@ cp /home/foundry/$SSH_USERNAME/foundry-banner /etc/update-motd.d/05-foundry-bann
 rm /home/foundry/$SSH_USERNAME/foundry-banner
 sed -i "s/{version}/$APPLIANCE_VERSION/" ~/mkdocs/docs/index.md
 echo -e "Foundry Appliance $APPLIANCE_VERSION \\\n \l \n" > /etc/issue
+
+# Create systemd service to configure netplan primary interface
+mv /home/foundry/foundry/configure-nic /usr/local/bin
+cat <<EOF > /etc/systemd/system/configure-nic.service
+[Unit]
+Description=Configure Netplan primary Ethernet interface
+After=network.target
+Before=k3s.service
+
+[Service]
+Type=oneshot
+ExecStart=configure-nic
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable configure-nic


### PR DESCRIPTION
When booting the new Ubuntu 22.04 appliance, netplan and dnsmasq did not include the correct Ethernet interface name. This adds a `configure-nic` script and systemd service to set those values on first boot.