### PR TITLE
TopoMojo v2.1.3 upgrade

### DIFF
--- a/foundry/topomojo/topomojo.values.yaml
+++ b/foundry/topomojo/topomojo.values.yaml
@@ -9,7 +9,7 @@ topomojo-api:
     repository: cmusei/topomojo-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.0.10"
+    tag: "2.1.3"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -166,7 +166,7 @@ topomojo-ui:
     repository: cmusei/topomojo-ui
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.0.10"
+    tag: "2.1.3"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/foundry/topomojo/topomojo.values.yaml
+++ b/foundry/topomojo/topomojo.values.yaml
@@ -166,7 +166,7 @@ topomojo-ui:
     repository: cmusei/topomojo-ui
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.1.3"
+    tag: "2.1.1"
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
Upgrade to [TopoMojo v2.1.3](https://github.com/cmu-sei/TopoMojo/releases/tag/2.1.3).

This upgrade adds a Dispatcher feature where TopoMojo can send commands and receive action triggers from a deployed gamespace.