### PR TITLE
Fix CSP error with Identity login page

### DIFF
--- a/foundry/common/identity.values.yaml
+++ b/foundry/common/identity.values.yaml
@@ -67,6 +67,7 @@ identity-api:
 #    Headers__Cors__AllowCredentials: true
     Headers__Forwarding__TargetHeaders: All
     Headers__Forwarding__KnownNetworks: "10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 ::ffff:a00:0/104 ::ffff:ac10:0/108 ::ffff:c0a8:0/112"
+    Headers__Security__ContentSecurity: "default-src 'self'; script-src 'self' 'unsafe-inline'; frame-ancestors 'self';"
 
   conf:
     issuers: ""


### PR DESCRIPTION
Identity 1.4.7 throws a Content Security Policy error on the login page:

> Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-3ljVrsDzCDTb+OYQGPrI7kFpqM5A5dwwb6HNd6ttNNk='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.

This fix updates the Content Security Policy for the Identity API deployment.