### PR TITLE
Fix VS Code syntax highlighting for install scripts

### DIFF
--- a/foundry/common/install.sh
+++ b/foundry/common/install.sh
@@ -44,7 +44,7 @@ helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
 helm install -f kubernetes-dashboard.values.yaml kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard
 
 # Add root CA to chart values
-ed -s mkdocs-material.values.yaml <<< $'/cacert:/s/\"\"/|-/\n/cacert:/r !sed "s/^/  /" ../certs/root-ca.pem\nw'
+cat ../certs/root-ca.pem | sed 's/^/  /' | sed -i -re 's/(cacert:).*/\1 |-/' -e '/cacert:/ r /dev/stdin' mkdocs-material.values.yaml
 cp ../certs/root-ca.pem ../../mkdocs/docs/root-ca.crt
 
 # Install Gitea

--- a/foundry/topomojo/install.sh
+++ b/foundry/topomojo/install.sh
@@ -19,8 +19,8 @@ kubectl config set-context --current --namespace=topomojo
 kubectl create secret tls appliance-cert --key ../certs/host-key.pem --cert <( cat ../certs/host.pem ../certs/int-ca.pem )
 
 # Add root CA to chart values
-ed -s gameboard.values.yaml <<< $'/cacert:/s/\"\"/|-/\n/cacert:/r !sed "s/^/    /" ../certs/root-ca.pem\nw'
-ed -s topomojo.values.yaml <<< $'/cacert.crt:/s/\"\"/|-/\n/cacert.crt:/r !sed "s/^/        /" ../certs/root-ca.pem\nw'
+cat ../certs/root-ca.pem | sed 's/^/    /' | sed -i -re 's/(cacert:).*/\1 |-/' -e '/cacert:/ r /dev/stdin' gameboard.values.yaml
+cat ../certs/root-ca.pem | sed 's/^/        /' | sed -i -re 's/(cacert.crt:).*/\1 |-/' -e '/cacert.crt:/ r /dev/stdin' topomojo.values.yaml
 
 # Install TopoMojo
 kubectl apply -f topomojo-pvc.yaml


### PR DESCRIPTION
Rewrite code to add root CA certificate to Helm values files.

Fixes longstanding issue where VS Code does not syntax highlight subsequent lines properly:
https://github.com/microsoft/vscode/issues/77675