### PR TITLE
GitHub Runner to macOS 12 & Ubuntu 22.04.1 ISO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -54,8 +54,8 @@ locals {
   ]
   cpus             = 2
   disk_size        = 30000
-  iso_url          = "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso"
-  iso_checksum     = "sha256:84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f"
+  iso_url          = "https://releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso"
+  iso_checksum     = "sha256:10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb"
   memory           = 4096
   shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"
 }


### PR DESCRIPTION
Migrating to the new macOS 12 runner image since the 10.15 image is deprecated:
https://github.com/actions/runner-images/issues/5583

Changes base ISO to Ubuntu 22.04.1 since the earlier version was removed from Canonical's site.