### PR TITLE
Enable Gitea SSO with Identity

### DIFF
--- a/foundry/common/gitea.values.yaml
+++ b/foundry/common/gitea.values.yaml
@@ -1,35 +1,142 @@
 # Default values for gitea.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+## @section Global
+#
+## @param global.imageRegistry global image registry override
+## @param global.imagePullSecrets global image pull secrets override; can be extended by `imagePullSecrets`
+## @param global.storageClass global storage class override
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
 
+## @param replicaCount number of replicas for the statefulset
 replicaCount: 1
 
+## @param clusterDomain cluster domain
 clusterDomain: cluster.local
 
+## @section Image
+## @param image.registry image registry, e.g. gcr.io,docker.io
+## @param image.repository Image to start for this pod
+## @param image.tag Visit: [Image tag](https://hub.docker.com/r/gitea/gitea/tags?page=1&ordering=last_updated). Defaults to `appVersion` within Chart.yaml.
+## @param image.pullPolicy Image pull policy
+## @param image.rootless Wether or not to pull the rootless version of Gitea, only works on Gitea 1.14.x or higher
 image:
+  registry: ""
   repository: gitea/gitea
-  tag: 1.15.10
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 1.17.3
   pullPolicy: Always
+  rootless: false # only possible when running 1.14 or later
 
+## @param imagePullSecrets Secret to use for pulling the image
 imagePullSecrets: []
 
+## @section Security
+# Security context is only usable with rootless image due to image design
+## @param podSecurityContext.fsGroup Set the shared file system group for all containers in the pod.
+podSecurityContext:
+  fsGroup: 1000
+
+## @param containerSecurityContext Security context
+containerSecurityContext: {}
+#   allowPrivilegeEscalation: false
+#   capabilities:
+#     drop:
+#       - ALL
+#   # Add the SYS_CHROOT capability for root and rootless images if you intend to
+#   # run pods on nodes that use the container runtime cri-o. Otherwise, you will
+#   # get an error message from the SSH server that it is not possible to read from
+#   # the repository.
+#   # https://gitea.com/gitea/helm-chart/issues/161
+#     add:
+#       - SYS_CHROOT
+#   privileged: false
+#   readOnlyRootFilesystem: true
+#   runAsGroup: 1000
+#   runAsNonRoot: true
+#   runAsUser: 1000
+
+## @depracated The securityContext variable has been split two:
+## - containerSecurityContext
+## - podSecurityContext.
+## @param securityContext Run init and Gitea containers as a specific securityContext
+securityContext: {}
+
+## @section Service
 service:
+  ## @param service.http.type Kubernetes service type for web traffic
+  ## @param service.http.port Port number for web traffic
+  ## @param service.http.clusterIP ClusterIP setting for http autosetup for statefulset is None
+  ## @param service.http.loadBalancerIP LoadBalancer IP setting
+  ## @param service.http.nodePort NodePort for http service
+  ## @param service.http.externalTrafficPolicy If `service.http.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable source IP preservation
+  ## @param service.http.externalIPs External IPs for service
+  ## @param service.http.ipFamilyPolicy HTTP service dual-stack policy
+  ## @param service.http.ipFamilies HTTP service dual-stack familiy selection,for dual-stack parameters see official kubernetes [dual-stack concept documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).
+  ## @param service.http.loadBalancerSourceRanges Source range filter for http loadbalancer
+  ## @param service.http.annotations HTTP service annotations
   http:
     type: ClusterIP
     port: 3000
+    clusterIP: None
+    loadBalancerIP:
+    nodePort:
+    externalTrafficPolicy:
+    externalIPs:
+    ipFamilyPolicy:
+    ipFamilies:
+    loadBalancerSourceRanges: []
+    annotations: {}
+  ## @param service.ssh.type Kubernetes service type for ssh traffic
+  ## @param service.ssh.port Port number for ssh traffic
+  ## @param service.ssh.clusterIP ClusterIP setting for ssh autosetup for statefulset is None
+  ## @param service.ssh.loadBalancerIP LoadBalancer IP setting
+  ## @param service.ssh.nodePort NodePort for ssh service
+  ## @param service.ssh.externalTrafficPolicy If `service.ssh.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable source IP preservation
+  ## @param service.ssh.externalIPs External IPs for service
+  ## @param service.ssh.ipFamilyPolicy SSH service dual-stack policy
+  ## @param service.ssh.ipFamilies SSH service dual-stack familiy selection,for dual-stack parameters see official kubernetes [dual-stack concept documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).
+  ## @param service.ssh.hostPort HostPort for ssh service
+  ## @param service.ssh.loadBalancerSourceRanges Source range filter for ssh loadbalancer
+  ## @param service.ssh.annotations SSH service annotations
   ssh:
     type: ClusterIP
     port: 22
-    #loadBalancerIP:
-    #nodePort:
-    #externalTrafficPolicy:
-    #externalIPs:
-    annotations:
+    clusterIP: None
+    loadBalancerIP:
+    nodePort:
+    externalTrafficPolicy:
+    externalIPs:
+    ipFamilyPolicy:
+    ipFamilies:
+    hostPort:
+    loadBalancerSourceRanges: []
+    annotations: {}
 
+
+## @section Ingress
+## @param ingress.enabled Enable ingress
+## @param ingress.className Ingress class name
+## @param ingress.annotations Ingress annotations
+## @param ingress.hosts[0].host Default Ingress host
+## @param ingress.hosts[0].paths[0].path Default Ingress path
+## @param ingress.hosts[0].paths[0].pathType Ingress path type
+## @param ingress.tls Ingress tls settings
+## @extra ingress.apiVersion Specify APIVersion of ingress object. Mostly would only be used for argocd.
 ingress:
   enabled: true
+  # className: nginx
+  className:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: foundry.local
@@ -40,45 +147,153 @@ ingress:
     - secretName: appliance-cert
       hosts:
         - foundry.local
+  # Mostly for argocd or any other CI that uses `helm template | kubectl apply` or similar
+  # If helm doesn't correctly detect your ingress API version you can set it here.
+  # apiVersion: networking.k8s.io/v1
 
-resources:
+## @section StatefulSet
+#
+## @param resources Kubernetes resources
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #   cpu: 200m
-  #   memory: 256Mi
+  #   cpu: 100m
+  #   memory: 128Mi
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
 
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+## @param schedulerName Use an alternate scheduler, e.g. "stork"
+schedulerName: ""
+
+## @param nodeSelector NodeSelector for the statefulset
 nodeSelector: {}
 
+## @param tolerations Tolerations for the statefulset
 tolerations: []
 
+## @param affinity Affinity for the statefulset
 affinity: {}
 
+## @param dnsConfig dnsConfig for the statefulset
+dnsConfig: {}
+
+## @param statefulset.env  Additional environment variables to pass to containers
+## @param statefulset.terminationGracePeriodSeconds How long to wait until forcefully kill the pod
+## @param statefulset.labels Labels for the statefulset
+## @param statefulset.annotations Annotations for the Gitea StatefulSet to be created
 statefulset:
   env: []
     # - name: VARIABLE
     #   value: my-value
   terminationGracePeriodSeconds: 60
+  labels: {}
+  annotations: {}
 
+## @section Persistence
+#
+## @param persistence.enabled Enable persistent storage
+## @param persistence.existingClaim Use an existing claim to store repository information
+## @param persistence.size Size for persistence to store repo information
+## @param persistence.accessModes AccessMode for persistence
+## @param persistence.labels Labels for the persistence volume claim to be created
+## @param persistence.annotations Annotations for the persistence volume claim to be created
+## @param persistence.storageClass Name of the storage class to use
+## @param persistence.subPath Subdirectory of the volume to mount at
 persistence:
   enabled: true
-  # existingClaim:
+  existingClaim:
   size: 1Gi
   accessModes:
     - ReadWriteOnce
+  labels: {}
+  annotations: {}
   storageClass: local-path
+  subPath:
 
+## @param extraVolumes Additional volumes to mount to the Gitea statefulset
+extraVolumes:
+  - name: appliance-cert-vol
+    secret:
+      secretName: appliance-cert
+
+## @param extraContainerVolumeMounts Mounts that are only mapped into the Gitea runtime/main container, to e.g. override custom templates.
+extraContainerVolumeMounts:
+  - name: appliance-cert-vol
+    mountPath: /etc/ssl/certs/appliance-ca.crt
+    subPath: tls.crt
+    readOnly: true
+
+## @param extraInitVolumeMounts Mounts that are only mapped into the init-containers. Can be used for additional preconfiguration.
+extraInitVolumeMounts: []
+
+## @depracated The extraVolumeMounts variable has been split two:
+## - extraContainerVolumeMounts
+## - extraInitVolumeMounts
+## As an example, can be used to mount a client cert when connecting to an external Postgres server.
+## @param extraVolumeMounts **DEPRECATED** Additional volume mounts for init containers and the Gitea main container
+extraVolumeMounts: []
+# - name: postgres-ssl-vol
+#   readOnly: true
+#   mountPath: "/pg-ssl"
+
+## @section Init
+## @param initPreScript Bash shell script copied verbatim to the start of the init-container.
+initPreScript: ""
+#
+# initPreScript: |
+#   mkdir -p /data/git/.postgresql
+#   cp /pg-ssl/* /data/git/.postgresql/
+#   chown -R git:git /data/git/.postgresql/
+#   chmod 400 /data/git/.postgresql/postgresql.key
+
+# Configure commit/action signing prerequisites
+## @section Signing
+#
+## @param signing.enabled Enable commit/action signing
+## @param signing.gpgHome GPG home directory
+## @param signing.privateKey Inline private gpg key for signed Gitea actions
+## @param signing.existingSecret Use an existing secret to store the value of `signing.privateKey`
+signing:
+  enabled: false
+  gpgHome: /data/git/.gnupg
+  privateKey: ""
+  # privateKey: |-
+  #   -----BEGIN PGP PRIVATE KEY BLOCK-----
+  #   ...
+  #   -----END PGP PRIVATE KEY BLOCK-----
+  existingSecret: ""
+
+## @section Gitea
+#
 gitea:
+  ## @param gitea.admin.username Username for the Gitea admin user
+  ## @param gitea.admin.existingSecret Use an existing secret to store admin user credentials
+  ## @param gitea.admin.password Password for the Gitea admin user
+  ## @param gitea.admin.email Email for the Gitea admin user
   admin:
+    #existingSecret: gitea-admin-secret
+    existingSecret:
     username: administrator
     password: foundry
     email: "administrator@foundry.local"
 
+  ## @param gitea.metrics.enabled Enable Gitea metrics
+  ## @param gitea.metrics.serviceMonitor.enabled Enable Gitea metrics service monitor
+  metrics:
+    enabled: false
+    serviceMonitor:
+      enabled: false
+      #  additionalLabels:
+      #    prometheus-release: prom1
+
+  ## @param gitea.ldap LDAP configuration
   ldap: []
     # - name: "LDAP 1"
     #  existingSecret:
@@ -94,6 +309,22 @@ gitea:
     #  usernameAttribute:
     #  publicSSHKeyAttribute:
 
+  # Either specify inline `key` and `secret` or refer to them via `existingSecret`
+  ## @param gitea.oauth OAuth configuration
+  oauth: []
+    # - name: 'OAuth 1'
+    #   provider:
+    #   key:
+    #   secret:
+    #   existingSecret:
+    #   autoDiscoverUrl:
+    #   useCustomUrls:
+    #   customAuthUrl:
+    #   customTokenUrl:
+    #   customProfileUrl:
+    #   customEmailUrl:
+
+  ## @param gitea.config  Configuration for the Gitea server,ref: [config-cheat-sheet](https://docs.gitea.io/en-us/config-cheat-sheet/)
   config:
     APP_NAME: Foundry Gitea
     server:
@@ -111,10 +342,31 @@ gitea:
     repository:
       DEFAULT_BRANCH: main
 
+  ## @param gitea.additionalConfigSources Additional configuration from secret or configmap
+  additionalConfigSources: []
+  #   - secret:
+  #       secretName: gitea-app-ini-oauth
+  #   - configMap:
+  #       name: gitea-app-ini-plaintext
+
+  ## @param gitea.additionalConfigFromEnvs Additional configuration sources from environment variables
+  additionalConfigFromEnvs: []
+
+  ## @param gitea.podAnnotations Annotations for the Gitea pod
   podAnnotations: {}
 
+  ## @section LivenessProbe
+  #
+  ## @param gitea.livenessProbe.enabled Enable liveness probe
+  ## @param gitea.livenessProbe.tcpSocket.port Port to probe for liveness
+  ## @param gitea.livenessProbe.initialDelaySeconds Initial delay before liveness probe is initiated
+  ## @param gitea.livenessProbe.timeoutSeconds Timeout for liveness probe
+  ## @param gitea.livenessProbe.periodSeconds Period for liveness probe
+  ## @param gitea.livenessProbe.successThreshold Success threshold for liveness probe
+  ## @param gitea.livenessProbe.failureThreshold Failure threshold for liveness probe
   # Modify the liveness probe for your needs or completely disable it by commenting out.
   livenessProbe:
+    enabled: true
     tcpSocket:
       port: http
     initialDelaySeconds: 200
@@ -123,8 +375,18 @@ gitea:
     successThreshold: 1
     failureThreshold: 10
 
+  ## @section ReadinessProbe
+  #
+  ## @param gitea.readinessProbe.enabled Enable readiness probe
+  ## @param gitea.readinessProbe.tcpSocket.port Port to probe for readiness
+  ## @param gitea.readinessProbe.initialDelaySeconds Initial delay before readiness probe is initiated
+  ## @param gitea.readinessProbe.timeoutSeconds Timeout for readiness probe
+  ## @param gitea.readinessProbe.periodSeconds Period for readiness probe
+  ## @param gitea.readinessProbe.successThreshold Success threshold for readiness probe
+  ## @param gitea.readinessProbe.failureThreshold Failure threshold for readiness probe
   # Modify the readiness probe for your needs or completely disable it by commenting out.
   readinessProbe:
+    enabled: true
     tcpSocket:
       port: http
     initialDelaySeconds: 5
@@ -134,20 +396,42 @@ gitea:
     failureThreshold: 3
 
   # # Uncomment the startup probe to enable and modify it for your needs.
-  # startupProbe:
-  #   tcpSocket:
-  #     port: http
-  #   initialDelaySeconds: 60
-  #   timeoutSeconds: 1
-  #   periodSeconds: 10
-  #   successThreshold: 1
-  #   failureThreshold: 10
+  ## @section StartupProbe
+  #
+  ## @param gitea.startupProbe.enabled Enable startup probe
+  ## @param gitea.startupProbe.tcpSocket.port Port to probe for startup
+  ## @param gitea.startupProbe.initialDelaySeconds Initial delay before startup probe is initiated
+  ## @param gitea.startupProbe.timeoutSeconds Timeout for startup probe
+  ## @param gitea.startupProbe.periodSeconds Period for startup probe
+  ## @param gitea.startupProbe.successThreshold Success threshold for startup probe
+  ## @param gitea.startupProbe.failureThreshold Failure threshold for startup probe
+  startupProbe:
+    enabled: false
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 60
+    timeoutSeconds: 1
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 10
 
+## @section Memcached
+#
+## @param memcached.enabled Memcached is loaded as a dependency from [Bitnami](https://github.com/bitnami/charts/tree/master/bitnami/memcached) if enabled in the values. Complete Configuration can be taken from their website.
+## @param memcached.service.port Port for Memcached
 memcached:
   enabled: true
   service:
     port: 11211
 
+## @section PostgreSQL
+#
+## @param postgresql.enabled Enable PostgreSQL
+## @param postgresql.global.postgresql.postgresqlDatabase PostgreSQL database (overrides postgresqlDatabase)
+## @param postgresql.global.postgresql.postgresqlUsername PostgreSQL username (overrides postgresqlUsername)
+## @param postgresql.global.postgresql.postgresqlPassword PostgreSQL admin password (overrides postgresqlPassword)
+## @param postgresql.global.postgresql.servicePort PostgreSQL port (overrides service.port)
+## @param postgresql.persistence.size PVC Storage Request for PostgreSQL volume
 postgresql:
   enabled: false
   global:
@@ -157,8 +441,17 @@ postgresql:
       postgresqlPassword: gitea
       servicePort: 5432
   persistence:
-    size: 1Gi
+    size: 10Gi
 
+## @section MySQL
+#
+## @param mysql.enabled Enable MySQL
+## @param mysql.root.password Password for the root user. Ignored if existing secret is provided
+## @param mysql.db.user Username of new user to create.
+## @param mysql.db.password Password for the new user.Ignored if existing secret is provided
+## @param mysql.db.name Name for new database to create.
+## @param mysql.service.port Port to connect to MySQL service
+## @param mysql.persistence.size PVC Storage Request for MySQL volume
 mysql:
   enabled: false
   root:
@@ -172,6 +465,15 @@ mysql:
   persistence:
     size: 10Gi
 
+## @section MariaDB
+#
+## @param mariadb.enabled Enable MariaDB
+## @param mariadb.auth.database Name of the database to create.
+## @param mariadb.auth.username Username of the new user to create.
+## @param mariadb.auth.password Password for the new user. Ignored if existing secret is provided
+## @param mariadb.auth.rootPassword Password for the root user.
+## @param mariadb.primary.service.port Port to connect to MariaDB service
+## @param mariadb.primary.persistence.size Persistence size for MariaDB
 mariadb:
   enabled: false
   auth:
@@ -185,4 +487,9 @@ mariadb:
     persistence:
       size: 10Gi
 
+# By default, removed or moved settings that still remain in a user defined values.yaml will cause Helm to fail running the install/update.
+# Set it to false to skip this basic validation check.
+## @section Advanced
+## @param checkDeprecation Set it to false to skip this basic validation check.
 checkDeprecation: true
+

--- a/foundry/common/gitea.values.yaml
+++ b/foundry/common/gitea.values.yaml
@@ -231,7 +231,11 @@ extraContainerVolumeMounts:
     readOnly: true
 
 ## @param extraInitVolumeMounts Mounts that are only mapped into the init-containers. Can be used for additional preconfiguration.
-extraInitVolumeMounts: []
+extraInitVolumeMounts:
+  - name: appliance-cert-vol
+    mountPath: /etc/ssl/certs/appliance-ca.crt
+    subPath: tls.crt
+    readOnly: true
 
 ## @depracated The extraVolumeMounts variable has been split two:
 ## - extraContainerVolumeMounts
@@ -311,13 +315,13 @@ gitea:
 
   # Either specify inline `key` and `secret` or refer to them via `existingSecret`
   ## @param gitea.oauth OAuth configuration
-  oauth: []
-    # - name: 'OAuth 1'
-    #   provider:
+  oauth:
+    - name: Foundry
+      provider: openidConnect
+      autoDiscoverUrl: https://foundry.local/identity/.well-known/openid-configuration
+      existingSecret: gitea-oauth-client
     #   key:
     #   secret:
-    #   existingSecret:
-    #   autoDiscoverUrl:
     #   useCustomUrls:
     #   customAuthUrl:
     #   customTokenUrl:
@@ -341,6 +345,11 @@ gitea:
       PASSWORD_COMPLEXITY: "off"
     repository:
       DEFAULT_BRANCH: main
+    oauth2_client:
+      OPENID_CONNECT_SCOPES: profile email
+      ENABLE_AUTO_REGISTRATION: true
+      USERNAME: userid
+      ACCOUNT_LINKING: auto
 
   ## @param gitea.additionalConfigSources Additional configuration from secret or configmap
   additionalConfigSources: []

--- a/foundry/common/gitea.values.yaml
+++ b/foundry/common/gitea.values.yaml
@@ -282,11 +282,10 @@ gitea:
   ## @param gitea.admin.password Password for the Gitea admin user
   ## @param gitea.admin.email Email for the Gitea admin user
   admin:
-    #existingSecret: gitea-admin-secret
-    existingSecret:
-    username: administrator
-    password: foundry
+    existingSecret: gitea-admin-creds
     email: "administrator@foundry.local"
+    # username:
+    # password:
 
   ## @param gitea.metrics.enabled Enable Gitea metrics
   ## @param gitea.metrics.serviceMonitor.enabled Enable Gitea metrics service monitor

--- a/foundry/common/identity.values.yaml
+++ b/foundry/common/identity.values.yaml
@@ -150,6 +150,20 @@ identity-api:
               { "Type": "RedirectUri", "Value": "https://foundry.local/topomojo/api/oauth2-redirect.html" },
               { "Type": "PostLogoutRedirectUri", "Value": "https://foundry.local/topomojo/api" }
             ]
+          },
+          {
+            "Name": "gitea-client",
+            "DisplayName": "Gitea",
+            "Enabled": true,
+            "SeedFlags" : "AllowRememberConsent",
+            "SeedGrant": "authorization_code",
+            "SeedScopes": "openid profile",
+            "SeedSecret": "<GITEA_OAUTH_CLIENT_SECRET>",
+            "Urls": [
+              { "Type": "ClientUri", "Value": "https://foundry.local/gitea" },
+              { "Type": "RedirectUri", "Value": "https://foundry.local/gitea/user/oauth2/foundry/callback" },
+              { "Type": "PostLogoutRedirectUri", "Value": "https://foundry.local/gitea" }
+            ]
           }
         ]
       }

--- a/foundry/common/identity.values.yaml
+++ b/foundry/common/identity.values.yaml
@@ -157,7 +157,7 @@ identity-api:
             "Enabled": true,
             "SeedFlags" : "AllowRememberConsent",
             "SeedGrant": "authorization_code",
-            "SeedScopes": "openid profile",
+            "SeedScopes": "openid profile email",
             "SeedSecret": "<GITEA_OAUTH_CLIENT_SECRET>",
             "Urls": [
               { "Type": "ClientUri", "Value": "https://foundry.local/gitea" },

--- a/foundry/common/install.sh
+++ b/foundry/common/install.sh
@@ -24,7 +24,7 @@ helm install -f nfs-server-provisioner.values.yaml nfs-server-provisioner kvaps/
 
 # Install ingress-nginx
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm install ingress-nginx ingress-nginx/ingress-nginx --values ingress-nginx.values.yaml
+helm install --wait ingress-nginx ingress-nginx/ingress-nginx --values ingress-nginx.values.yaml
 
 # Install PostgreSQL
 helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/foundry/common/install.sh
+++ b/foundry/common/install.sh
@@ -8,6 +8,8 @@
 #   Common Stack Install   #
 ############################
 
+GITEA_OAUTH_CLIENT_SECRET=$(openssl rand -hex 16)
+
 # Change to the current directory
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -47,15 +49,19 @@ helm install -f kubernetes-dashboard.values.yaml kubernetes-dashboard kubernetes
 cat ../certs/root-ca.pem | sed 's/^/  /' | sed -i -re 's/(cacert:).*/\1 |-/' -e '/cacert:/ r /dev/stdin' mkdocs-material.values.yaml
 cp ../certs/root-ca.pem ../../mkdocs/docs/root-ca.crt
 
+# Install Identity
+sed -i -r "s/<GITEA_OAUTH_CLIENT_SECRET>/$GITEA_OAUTH_CLIENT_SECRET/" identity.values.yaml
+helm repo add sei https://helm.cyberforce.site/charts
+helm install --wait -f identity.values.yaml identity sei/identity
+
 # Install Gitea
 git config --global init.defaultBranch main
 helm repo add gitea https://dl.gitea.io/charts/
 kubectl exec postgresql-0 -- psql 'postgresql://postgres:foundry@localhost' -c 'CREATE DATABASE gitea;'
+kubectl create secret generic gitea-oauth-client --from-literal=key=gitea-client --from-literal=secret=$GITEA_OAUTH_CLIENT_SECRET
 helm install -f gitea.values.yaml gitea gitea/gitea
 timeout 5m bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://foundry.local/gitea)" != "200" ]]; do sleep 5; done' || false
 ./setup-gitea
 
-# Foundry Stack install
-helm repo add sei https://helm.cyberforce.site/charts
-helm install -f identity.values.yaml identity sei/identity
+# Install Material for MkDocs
 helm install -f mkdocs-material.values.yaml mkdocs-material sei/mkdocs-material

--- a/foundry/common/install.sh
+++ b/foundry/common/install.sh
@@ -9,6 +9,7 @@
 ############################
 
 GITEA_OAUTH_CLIENT_SECRET=$(openssl rand -hex 16)
+GITEA_ADMIN_PASSWORD=$(pwgen 12)
 
 # Change to the current directory
 cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -59,6 +60,7 @@ git config --global init.defaultBranch main
 helm repo add gitea https://dl.gitea.io/charts/
 kubectl exec postgresql-0 -- psql 'postgresql://postgres:foundry@localhost' -c 'CREATE DATABASE gitea;'
 kubectl create secret generic gitea-oauth-client --from-literal=key=gitea-client --from-literal=secret=$GITEA_OAUTH_CLIENT_SECRET
+kubectl create secret generic gitea-admin-creds --from-literal=username=administrator --from-literal=password=$GITEA_ADMIN_PASSWORD
 helm install -f gitea.values.yaml gitea gitea/gitea
 timeout 5m bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://foundry.local/gitea)" != "200" ]]; do sleep 5; done' || false
 ./setup-gitea

--- a/foundry/common/setup-gitea
+++ b/foundry/common/setup-gitea
@@ -4,9 +4,10 @@
 # Released under a BSD (SEI)-style license, please see LICENSE.md in the
 # project root or contact permission@sei.cmu.edu for full terms.
 
+GITEA_ADMIN_PASSWORD=$(kubectl get secret gitea-admin-creds -o json | jq -r .data.password | base64 -d)
 CURL_OPTS=( --silent --header "accept: application/json" --header "Content-Type: application/json" )
 USER_TOKEN=$( curl "${CURL_OPTS[@]}" \
-                --user administrator:foundry \
+                --user administrator:$GITEA_ADMIN_PASSWORD \
                 --request POST "https://foundry.local/gitea/api/v1/users/administrator/tokens" \
                 --data "{ \"name\": \"appliance-setup\"}" | jq -r '.sha1'
 )
@@ -43,4 +44,4 @@ EOF
 git -C $MKDOCS_DIR init
 git -C $MKDOCS_DIR add -A
 git -C $MKDOCS_DIR commit -m "Initial commit"
-git -C $MKDOCS_DIR push -u https://administrator:foundry@foundry.local/gitea/foundry/mkdocs.git --all
+git -C $MKDOCS_DIR push -u https://administrator:$GITEA_ADMIN_PASSWORD@foundry.local/gitea/foundry/mkdocs.git --all

--- a/setup-appliance
+++ b/setup-appliance
@@ -58,7 +58,7 @@ network:
 EOF
 netplan apply
 
-apt-get install -y dnsmasq avahi-daemon jq nfs-common sshpass kubectl helm
+apt-get install -y dnsmasq avahi-daemon jq nfs-common sshpass kubectl helm pwgen
 
 # Install k3s
 mkdir -p /etc/rancher/k3s


### PR DESCRIPTION
Upgrades the appliance to [Gitea 1.17.3](https://github.com/go-gitea/gitea/releases/tag/v1.17.3) and adds Identity as an OAuth2 authentication source.

The Gitea administrator account is linked to default Identity administrator account, so changing two passwords is no longer necessary. Further, the native Gitea administrator password is now randomly generated at build and stored in the `gitea-admin-creds` secret in the `common` namespace.