### PR TITLE
Revert pgAdmin4 upgrade

### DIFF
--- a/foundry/common/pgadmin4.values.yaml
+++ b/foundry/common/pgadmin4.values.yaml
@@ -8,7 +8,7 @@ image:
   registry: docker.io
   repository: dpage/pgadmin4
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "6.15"
+  tag: "6.8"
   pullPolicy: IfNotPresent
 
 ## Deployment annotations
@@ -228,7 +228,7 @@ VolumePermissions:
 ##
 extraInitContainers: |
   - name: prepare-pgpass
-    image: "dpage/pgadmin4:6.7"
+    image: "dpage/pgadmin4:6.8"
     command:
       - "sh"
       - "-c"


### PR DESCRIPTION
Authenticating as `administrator@foundry.local` with pgAdmin4 fails with versions 6.9+. This is because `.local` is a [special use domain](https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml) and pgAdmin4 uses [Flask-Security-Too](https://github.com/Flask-Middleware/flask-security) and ultimately [email-validator](https://github.com/JoshData/python-email-validator) for this validation.

Error from pgAdmin4 container:
```
The domain name foundry.local is a special-use or reserved name that cannot be used with email.
```

While pgAdmin4 has a `SECURITY_EMAIL_VALIDATOR_ARGS` option to pass arguments to email-validator, that doesn't allow for modifying the `SPECIAL_USE_DOMAIN_NAMES` global for that library.

https://github.com/JoshData/python-email-validator/issues/78#issuecomment-1114353263

This fix reverts to a working version of pgAdmin 4 (6.8). Hopefully moving to OAuth2 for the login will fix this going forward.