### PR TITLE
v0.9.0

### DIFF
--- a/foundry-appliance.pkr.hcl
+++ b/foundry-appliance.pkr.hcl
@@ -14,7 +14,7 @@ source "virtualbox-iso" "foundry-appliance" {
   rtc_time_base        = "UTC"
   shutdown_command     = "${local.shutdown_command}"
   ssh_password         = "${var.ssh_password}"
-  ssh_timeout          = "30m"
+  ssh_timeout          = "60m"
   ssh_username         = "${var.ssh_username}"
   vboxmanage           = [
                            ["modifyvm", "{{.Name}}", "--vram", "${local.video_memory}"],
@@ -38,7 +38,7 @@ source "vmware-iso" "foundry-appliance" {
   output_directory     = "output-vmware"
   shutdown_command     = "${local.shutdown_command}"
   ssh_password         = "${var.ssh_password}"
-  ssh_timeout          = "30m"
+  ssh_timeout          = "60m"
   ssh_username         = "${var.ssh_username}"
   version              = "14"
   vm_name              = "foundry-appliance-${var.appliance_version}"
@@ -63,7 +63,7 @@ source "vsphere-iso" "foundry-appliance" {
   RAM              = "${local.memory}"
   shutdown_command = "${local.shutdown_command}"
   ssh_password     = "${var.ssh_password}"
-  ssh_timeout      = "30m"
+  ssh_timeout      = "60m"
   ssh_username     = "${var.ssh_username}"
   storage {
     disk_size             = "${local.disk_size}"

--- a/foundry-appliance.pkr.hcl
+++ b/foundry-appliance.pkr.hcl
@@ -14,7 +14,7 @@ source "virtualbox-iso" "foundry-appliance" {
   rtc_time_base        = "UTC"
   shutdown_command     = "${local.shutdown_command}"
   ssh_password         = "${var.ssh_password}"
-  ssh_timeout          = "20m"
+  ssh_timeout          = "30m"
   ssh_username         = "${var.ssh_username}"
   vboxmanage           = [
                            ["modifyvm", "{{.Name}}", "--vram", "${local.video_memory}"],
@@ -38,7 +38,7 @@ source "vmware-iso" "foundry-appliance" {
   output_directory     = "output-vmware"
   shutdown_command     = "${local.shutdown_command}"
   ssh_password         = "${var.ssh_password}"
-  ssh_timeout          = "20m"
+  ssh_timeout          = "30m"
   ssh_username         = "${var.ssh_username}"
   version              = "14"
   vm_name              = "foundry-appliance-${var.appliance_version}"
@@ -63,7 +63,7 @@ source "vsphere-iso" "foundry-appliance" {
   RAM              = "${local.memory}"
   shutdown_command = "${local.shutdown_command}"
   ssh_password     = "${var.ssh_password}"
-  ssh_timeout      = "20m"
+  ssh_timeout      = "30m"
   ssh_username     = "${var.ssh_username}"
   storage {
     disk_size             = "${local.disk_size}"

--- a/foundry/code-server.values.yaml
+++ b/foundry/code-server.values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '4.9.1'
+  tag: '4.18.0'
   pullPolicy: Always
 
 # Specifies one or more secrets to be used when pulling images from a

--- a/foundry/gameboard.values.yaml
+++ b/foundry/gameboard.values.yaml
@@ -9,7 +9,7 @@ gameboard-api:
     repository: cmusei/gameboard-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "3.7.1"
+    tag: "3.11.5"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -141,7 +141,7 @@ gameboard-ui:
     repository: cmusei/gameboard-ui
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "3.7.2"
+    tag: "3.11.4"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/foundry/identity.values.yaml
+++ b/foundry/identity.values.yaml
@@ -4,7 +4,7 @@ identity-api:
 
   image:
     repository: cmusei/identity
-    tag: "1.4.8"
+    tag: "1.5.4"
 
   ingress:
     enabled: true
@@ -175,7 +175,7 @@ identity-ui:
 
   image:
     repository: cmusei/identity-ui
-    tag: "1.4.7"
+    tag: "1.5.0"
 
   ingress:
     enabled: true

--- a/foundry/install.sh
+++ b/foundry/install.sh
@@ -39,7 +39,7 @@ kubectl create secret generic pgpassfile --from-literal=pgpassfile=postgresql:54
 helm install -f pgadmin4.values.yaml pgadmin4 runix/pgadmin4
 
 # Install code-server (browser-based VS Code)
-helm repo add sei https://helm.cyberforce.site/charts
+helm repo add sei https://helm.cmusei.dev/charts
 helm install -f code-server.values.yaml code-server sei/code-server
 
 # Kubernetes Dashboard

--- a/foundry/install.sh
+++ b/foundry/install.sh
@@ -36,7 +36,7 @@ helm install --wait -f postgresql.values.yaml postgresql bitnami/postgresql --ve
 # Install pgAdmin4
 helm repo add runix https://helm.runix.net/
 kubectl create secret generic pgpassfile --from-literal=pgpassfile=postgresql:5432:\*:postgres:foundry
-helm install -f pgadmin4.values.yaml pgadmin4 runix/pgadmin4 --version 1.14.3
+helm install -f pgadmin4.values.yaml pgadmin4 runix/pgadmin4 --version 1.18.2
 
 # Install code-server (browser-based VS Code)
 helm repo add sei https://helm.cmusei.dev/charts

--- a/foundry/mkdocs-material.values.yaml
+++ b/foundry/mkdocs-material.values.yaml
@@ -8,7 +8,7 @@ image:
   repository: squidfunk/mkdocs-material
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "9.0.4"
+  tag: "9.4.7"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/foundry/pgadmin4.values.yaml
+++ b/foundry/pgadmin4.values.yaml
@@ -8,7 +8,7 @@ image:
   registry: docker.io
   repository: dpage/pgadmin4
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "6.8"
+  tag: "7.8"
   pullPolicy: IfNotPresent
 
 ## Deployment annotations
@@ -48,6 +48,10 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Opt out of API credential automounting.
+  # If you don't want the kubelet to automatically mount a ServiceAccount's API credentials,
+  # you can opt out of the default behavior
+  automountServiceAccountToken: false
 
 ## Strategy used to replace old Pods by new ones
 ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
@@ -66,6 +70,10 @@ serverDefinitions:
   ## If true, server definitions will be created
   ##
   enabled: true
+
+  ## The resource type to use for deploying server definitions.
+  ## Can either be ConfigMap or Secret
+  resourceType: ConfigMap
 
   servers:
     foundry:
@@ -224,6 +232,10 @@ VolumePermissions:
   ##
   enabled: false
 
+## @param extraDeploy list of extra manifests to deploy
+##
+extraDeploy: []
+
 ## Additional InitContainers to initialize the pod
 ##
 extraInitContainers: |
@@ -290,6 +302,10 @@ podAnnotations: {}
 podLabels: {}
   # key1: value1
   # key2: value2
+
+# -- The name of the Namespace to deploy
+# If not set, `.Release.Namespace` is used
+namespace: null
 
 init:
   ## Init container resources

--- a/foundry/postgresql.values.yaml
+++ b/foundry/postgresql.values.yaml
@@ -87,7 +87,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 14.5.0-debian-11-r38
+  tag: 14.9.0-debian-11-r58
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/foundry/topomojo.values.yaml
+++ b/foundry/topomojo.values.yaml
@@ -9,7 +9,7 @@ topomojo-api:
     repository: cmusei/topomojo-api
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.1.6"
+    tag: "2.2.5"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -166,7 +166,7 @@ topomojo-ui:
     repository: cmusei/topomojo-ui
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.1.6"
+    tag: "2.2.4"
 
   imagePullSecrets: []
   nameOverride: ""

--- a/setup-appliance
+++ b/setup-appliance
@@ -17,10 +17,17 @@ swapoff -a
 sed -i -r 's/(\/swap\.img.*)/#\1/' /etc/fstab
 
 # Add new repositories and upgrade existing Ubuntu packages
-curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/helm.gpg > /dev/null
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+## Add Kubernetes Apt Repo
+apt-get update
+apt-get install -y apt-transport-https ca-certificates curl
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+## Add Helm Apt Repo
+curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+
+## Update and Upgrade
 apt-get update
 apt-get full-upgrade -y
 

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -55,7 +55,7 @@ locals {
   cpus             = 2
   disk_size        = 40000
   iso_url          = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
-  iso_checksum     = "sha256:5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931"
+  iso_checksum     = "sha256:a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd"
   memory           = 4096
   shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"
   video_memory     = 32

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -54,7 +54,7 @@ locals {
   ]
   cpus             = 2
   disk_size        = 40000
-  iso_url          = "https://releases.ubuntu.com/22.04.2/ubuntu-22.04.2-live-server-amd64.iso"
+  iso_url          = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
   iso_checksum     = "sha256:5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931"
   memory           = 4096
   shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -56,7 +56,7 @@ locals {
   disk_size        = 40000
   iso_url          = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
   iso_checksum     = "sha256:a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd"
-  memory           = 4096
+  memory           = 8192
   shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"
   video_memory     = 32
 }


### PR DESCRIPTION
The v0.9.0 release addresses a few build errors and updated application versions. This release also extends the SSH timeout on the Packer build and increases the RAM allocated to the appliance VM to 8GBs.

### Build Errors
1. Updates the Kubernetes Apt Repository 
2. Updates Ubuntu ISO download URLs and Hashes 
3. Adds pinned versions of Helm Charts to `helm install` commands to improve build consistency -- you'll always get the same version of the helm chart when this version is built. 

### App Updates
1. Identity API/UI to 1.5.4/1.5.0
2. TopoMojo API/UI to 2.2.5/2.2.4
3. Gameboard API/UI to 3.11.5/3.11.4
4. Postgres to 14.9
5. Pgadmin4 to 7.8
6. Material for MkDocs to 9.4.7
7. Code Server to 4.18.0