### PR TITLE
Fix systemd service order

### DIFF
--- a/foundry/charts/foundry/files/mkdocs/docs/index.md
+++ b/foundry/charts/foundry/files/mkdocs/docs/index.md
@@ -8,7 +8,7 @@ The appliance advertises the _foundry.local_ domain via mDNS. All apps are serve
 
 To get started using the virtual appliance:
 
-1. Download [ca.crt](ca.crt) and trust it in your keychain/certificate store. This removes browser certificate warnings.
+1. Download [foundry-ca.crt](assets/foundry-ca.crt) and trust it in your keychain/certificate store. This removes browser certificate warnings.
 2. Navigate to any of the apps in the following two sections.
 3. Unless otherwise noted, the default credentials are:
 

--- a/foundry/charts/foundry/templates/configmap.yaml
+++ b/foundry/charts/foundry/templates/configmap.yaml
@@ -125,6 +125,10 @@ data:
     git config --global init.defaultBranch main
 
     cp -RL /mkdocs /tmp
+
+    # Copy Foundry CA certificate to mkdocs assets
+    cp /foundry-ca/ca.crt /tmp/mkdocs/docs/assets/foundry-ca.crt
+
     git -C /tmp/mkdocs init
     git -C /tmp/mkdocs add -A
     git -C /tmp/mkdocs commit -m "Initial commit"

--- a/foundry/charts/foundry/templates/job.yaml
+++ b/foundry/charts/foundry/templates/job.yaml
@@ -97,6 +97,9 @@ spec:
               mountPath: /mkdocs
             - name: script
               mountPath: /scripts
+            - name: foundry-ca-cert
+              mountPath: /foundry-ca
+              readOnly: true
       volumes:
         - name: mkdocs
           configMap:
@@ -110,3 +113,9 @@ spec:
           configMap:
             name: {{ include "foundry.fullname" . }}-gitea-job-script
             defaultMode: 0755
+        - name: foundry-ca-cert
+          secret:
+            secretName: {{ .Values.global.infraHelmRelease }}-ca
+            items:
+            - key: ca.crt
+              path: ca.crt

--- a/setup-appliance.sh
+++ b/setup-appliance.sh
@@ -66,18 +66,7 @@ chmod 600 /etc/netplan/01-loopback.yaml
 netplan apply
 
 # Install apt packages
-apt-get install -y dnsmasq avahi-daemon nfs-common sshpass kubectl helm pwgen build-essential
-
-# Install VirtualBox Guest Additions
-if [ -f ~/VBoxGuestAdditions.iso ]; then
-  mount -o loop,ro ~/VBoxGuestAdditions.iso /mnt
-
-  # Temporarily disable exit on errors, since the VirtualBox Guest Additions installer returns '2'
-  set +e; /mnt/VBoxLinuxAdditions.run; set -e
-
-  umount /mnt
-  rm ~/VBoxGuestAdditions.iso
-fi
+apt-get install -y dnsmasq avahi-daemon nfs-common sshpass kubectl helm pwgen
 
 # Install k-alias Kubernetes helper scripts
 git clone https://github.com/jaggedmountain/k-alias.git /tmp/k-alias

--- a/setup-appliance.sh
+++ b/setup-appliance.sh
@@ -103,7 +103,6 @@ cat <<EOF >/etc/systemd/system/configure-nic.service
 [Unit]
 Description=Configure Netplan primary Ethernet interface (first boot)
 After=network.target
-Before=k3s.service
 
 [Service]
 Type=oneshot
@@ -120,7 +119,7 @@ rm ~/scripts/install-foundry.sh
 cat <<EOF >/etc/systemd/system/install-foundry.service
 [Unit]
 Description=Install Foundry chart (first boot)
-After=network-online.target
+After=configure-nic.service
 Requires=network-online.target
 
 [Service]


### PR DESCRIPTION
Fixes an issue where the `configure-nic` and `install-foundry` systemd services come up simultaneously, causing the k3s install to fail.

Also fixes the Foundry CA certificate link on the landing page.