### PR TITLE
Fix Gameboard and TopoMojo administrator access

### DIFF
--- a/foundry/charts/foundry/Chart.yaml
+++ b/foundry/charts/foundry/Chart.yaml
@@ -29,4 +29,4 @@ dependencies:
     version: 0.5.2
   - name: gameboard
     repository: https://helm.cmusei.dev/charts
-    version: 0.5.1
+    version: 0.5.3

--- a/foundry/charts/foundry/templates/job.yaml
+++ b/foundry/charts/foundry/templates/job.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    helm.sh/hook-weight: "10"
+    helm.sh/hook-weight: "15"
 spec:
   template:
     spec:
@@ -119,3 +119,101 @@ spec:
             items:
             - key: ca.crt
               path: ca.crt
+
+---
+{{- /* Add foundry user to realm of the same name */ -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "foundry.fullname" . }}-add-foundry-user
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "10"
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: curl
+          image: alpine/curl:latest
+          env:
+            - name: KEYCLOAK_ADMIN_USER
+              value: {{ .Values.keycloak.auth.adminUser }}
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "foundry.fullname" . }}-keycloak-auth
+                  key: admin-password
+            - name: KEYCLOAK_URL
+              value: https://{{ .Values.global.domain }}/keycloak
+            - name: KEYCLOAK_FOUNDRY_USER_GUID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "foundry.fullname" . }}-keycloak-auth
+                  key: foundry-user-guid
+            - name: KEYCLOAK_FOUNDRY_USERNAME
+              value: foundry
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              echo "Waiting for Keycloak to be ready..."
+              until curl -sfk "${KEYCLOAK_URL}/realms/master" > /dev/null 2>&1; do
+                echo "Keycloak not ready, waiting 10 seconds..."
+                sleep 10
+              done
+              echo "Keycloak is ready!"
+
+              echo "Getting admin access token..."
+              ACCESS_TOKEN=$(curl -sk -X POST \
+                "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+                -H "Content-Type: application/x-www-form-urlencoded" \
+                -d "grant_type=password" \
+                -d "client_id=admin-cli" \
+                -d "username=${KEYCLOAK_ADMIN_USER}" \
+                -d "password=${KEYCLOAK_ADMIN_PASSWORD}" | \
+                grep -o '"access_token":"[^"]*' | \
+                grep -o '[^"]*$')
+
+              echo "Searching for existing user '${KEYCLOAK_FOUNDRY_USERNAME}' by username..."
+              USERS_JSON=$(curl -sk -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                "${KEYCLOAK_URL}/admin/realms/foundry/users?username=${KEYCLOAK_FOUNDRY_USERNAME}")
+
+              NOW_MS=$(( $(date +%s) * 1000 ))
+
+              if echo "${USERS_JSON}" | grep -q '"id"'; then
+                echo "User '${KEYCLOAK_FOUNDRY_USERNAME}' already exists, skipping import."
+              else
+                echo "User '${KEYCLOAK_FOUNDRY_USERNAME}' not found, importing now..."
+                curl -k -X POST \
+                  "${KEYCLOAK_URL}/admin/realms/foundry/partialImport" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d '{
+                    "users": [
+                      {
+                        "id": "'"${KEYCLOAK_FOUNDRY_USER_GUID}"'",
+                        "username": "foundry",
+                        "email": "administrator@{{ .Values.global.domain }}",
+                        "firstName": "Foundry",
+                        "lastName": "Administrator",
+                        "enabled": true,
+                        "createdTimestamp": "'"${NOW_MS}"'",
+                        "credentials": [
+                          {
+                            "type": "password",
+                            "value": "foundry",
+                            "userLabel": "initial",
+                            "temporary": true
+                          }
+                        ],
+                        "requiredActions":["UPDATE_PASSWORD"],
+                        "realmRoles": ["foundry-admin"]
+                      }
+                    ]
+                  }'
+              fi

--- a/foundry/charts/foundry/templates/secret.yaml
+++ b/foundry/charts/foundry/templates/secret.yaml
@@ -1,4 +1,4 @@
-# Persist postgres account password on a chart reinstall
+{{- /* Persist postgres account password on a chart reinstall */ -}}
 {{- $postgresPassword := "" }}
 {{- $postgresqlSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-postgresql" (include "foundry.fullname" .)) }}
 {{- if $postgresqlSecret }}
@@ -33,41 +33,21 @@ type: Opaque
 data:
   admin-password: {{ if $giteaSecret }}{{ index $giteaSecret.data "admin-password" }}{{ else }}{{ randAlphaNum 16 | b64enc | quote }}{{ end }}
 
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "foundry.fullname" $ }}-topomojo-api-dbconnection
-  labels:
-    {{- include "foundry.labels" $ | nindent 4 }}
-type: Opaque
-stringData:
-  appsettings.conf: |
-    Database__ConnectionString = Server={{ include "foundry.fullname" $ }}-postgresql;Port=5432;Database=topomojo;Username=postgres;Password={{ $postgresPassword }};SSL Mode=Prefer;Trust Server Certificate=true;
-  cacert.crt: |
-    {{- index (lookup "v1" "Secret" .Release.Namespace (printf "%s-ca" .Values.global.infraHelmRelease)).data "ca.crt" | b64dec | nindent 4 }}
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "foundry.fullname" $ }}-gameboard-api-dbconnection
-  labels:
-    {{- include "foundry.labels" $ | nindent 4 }}
-type: Opaque
-stringData:
-  Database__ConnectionString: Server={{ include "foundry.fullname" $ }}-postgresql;Port=5432;Database=gameboard;Username=postgres;Password={{ $postgresPassword }};SSL Mode=Prefer;Trust Server Certificate=true;
 
 ---
 {{- $keycloakSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-keycloak-auth" (include "foundry.fullname" .)) -}}
 {{- $keycloakAdminPassword := randAlphaNum 16 -}}
 {{- $keycloakOauthClientSecret := (randBytes 16 | b64dec | printf "%032x") -}}
+{{- $keycloakFoundryUserGuid := uuidv4 -}}
 
 {{- if and $keycloakSecret (hasKey $keycloakSecret.data "admin-password") -}}
   {{- $keycloakAdminPassword = (index $keycloakSecret.data "admin-password" | b64dec) -}}
 {{- end }}
 {{- if and $keycloakSecret (hasKey $keycloakSecret.data "oauth-client-secret") -}}
   {{- $keycloakOauthClientSecret = (index $keycloakSecret.data "oauth-client-secret" | b64dec) -}}
+{{- end }}
+{{- if and $keycloakSecret (hasKey $keycloakSecret.data "foundry-user-guid") -}}
+  {{- $keycloakFoundryUserGuid = (index $keycloakSecret.data "foundry-user-guid" | b64dec) -}}
 {{- end }}
 
 apiVersion: v1
@@ -82,6 +62,7 @@ type: Opaque
 stringData:
   admin-password: {{ $keycloakAdminPassword }}
   oauth-client-secret: {{ $keycloakOauthClientSecret }}
+  foundry-user-guid: {{ $keycloakFoundryUserGuid }}
 
 ---
 {{- /* TODO: Share oauth-client-secret and move this back to configmap.yaml */ -}}
@@ -180,7 +161,7 @@ data:
           ],
           "rootUrl": "https://{{ .Values.global.domain }}/topomojo",
           "baseUrl": "/",
-          "defaultClientScopes": ["openid", "profile", "topomojo-api"],
+          "defaultClientScopes": ["profile", "topomojo-api"],
           "attributes": {
             "pkce.code.challenge.method": "S256"
           }
@@ -217,7 +198,7 @@ data:
           ],
           "rootUrl": "https://{{ .Values.global.domain }}/gameboard",
           "baseUrl": "/",
-          "defaultClientScopes": [ "openid", "profile", "gameboard-api" ],
+          "defaultClientScopes": ["profile", "gameboard-api"],
           "attributes": {
             "pkce.code.challenge.method": "S256"
           }
@@ -236,7 +217,7 @@ data:
           ],
           "rootUrl": "https://{{ .Values.global.domain }}/gameboard/api",
           "baseUrl": "/",
-          "defaultClientScopes": ["openid", "profile", "gameboard-api"],
+          "defaultClientScopes": ["gameboard-api"],
           "attributes": {
             "consent.required": "true"
           }
@@ -256,7 +237,7 @@ data:
           ],
           "rootUrl": "https://{{ .Values.global.domain }}/gitea",
           "baseUrl": "/",
-          "defaultClientScopes": ["openid", "profile", "email"],
+          "defaultClientScopes": ["profile", "email"],
           "attributes": {
             "oauth2.device.authorization.grant.enabled": "false"
           }
@@ -277,23 +258,32 @@ data:
             }
           }
         ]
-      },
-      "users": [
-        {
-          "username": "foundry",
-          "email": "administrator@foundry.local",
-          "firstName": "Foundry",
-          "lastName": "Administrator",
-          "enabled": true,
-          "credentials": [
-            {
-              "type": "password",
-              "value": "foundry",
-              "userLabel": "initial",
-              "temporary": true
-            }
-          ],
-          "realmRoles": ["foundry-admin"]
-        }
-      ]
+      }
     }
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "foundry.fullname" $ }}-topomojo-api-custom
+  labels:
+    {{- include "foundry.labels" $ | nindent 4 }}
+type: Opaque
+stringData:
+  appsettings.conf: |
+    Database__ConnectionString = Server={{ include "foundry.fullname" $ }}-postgresql;Port=5432;Database=topomojo;Username=postgres;Password={{ $postgresPassword }};SSL Mode=Prefer;Trust Server Certificate=true;
+    Database__AdminId = {{ $keycloakFoundryUserGuid }}
+  cacert.crt: |
+    {{- index (lookup "v1" "Secret" .Release.Namespace (printf "%s-ca" .Values.global.infraHelmRelease)).data "ca.crt" | b64dec | nindent 4 }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "foundry.fullname" $ }}-gameboard-api-custom
+  labels:
+    {{- include "foundry.labels" $ | nindent 4 }}
+type: Opaque
+stringData:
+  Database__ConnectionString: Server={{ include "foundry.fullname" $ }}-postgresql;Port=5432;Database=gameboard;Username=postgres;Password={{ $postgresPassword }};SSL Mode=Prefer;Trust Server Certificate=true;
+  Database__AdminId: {{ $keycloakFoundryUserGuid }}

--- a/foundry/charts/foundry/values.yaml
+++ b/foundry/charts/foundry/values.yaml
@@ -102,9 +102,6 @@ keycloak:
     tls: true
   keycloakConfigCli:
     enabled: true
-    extraEnvVars:
-      - name: IMPORT_MANAGED_CLIENTS
-        value: "full"
     existingConfigmap: '{{ include "foundry.fullname" . }}-config-cli'
   postgresql:
     enabled: false
@@ -209,7 +206,7 @@ topomojo:
           secretName: '{{ include "foundry.fullname" . }}-cert'
     storage:
       existing: '{{ include "foundry.fullname" . }}-nfs'
-    existingSecret: '{{ include "foundry.fullname" . }}-dbconnection'
+    existingSecret: '{{ include "foundry.fullname" . }}-custom'
     customStart:
       command: ['/bin/sh']
       args: ['/home/app/start/start.sh']
@@ -221,8 +218,7 @@ topomojo:
     env:
       PathBase: /topomojo
       Database__Provider: PostgreSQL
-      Database__AdminId: 704d16ba-b969-45c2-843a-c12589963e77
-      Database__AdminName: Administrator
+      Database__AdminName: Foundry Administrator
       Cache__SharedFolder: ""
       OpenApi__Client__ClientId: topomojo-swagger
       FileUpload__IsoRoot: /mnt/tm
@@ -297,10 +293,12 @@ gameboard:
     storage:
       size: "1Gi"
       class: local-path
-    existingSecret: '{{ include "foundry.fullname" . }}-dbconnection'
+    existingSecret: '{{ include "foundry.fullname" . }}-custom'
+    cacertSecret: '{{ .Values.global.infraHelmRelease }}-ca'
     env:
       PathBase: /gameboard
       Database__Provider: PostgreSQL
+      Database__AdminName: Foundry Administrator
       Oidc__Audience: gameboard-api
       Oidc__Authority: https://{{ .Values.global.domain }}/keycloak/realms/foundry
       OpenApi__Client__ClientId: gameboard-swagger

--- a/setup-appliance.sh
+++ b/setup-appliance.sh
@@ -66,7 +66,7 @@ chmod 600 /etc/netplan/01-loopback.yaml
 netplan apply
 
 # Install apt packages
-apt-get install -y dnsmasq avahi-daemon nfs-common sshpass kubectl helm pwgen
+apt-get install -y dnsmasq avahi-daemon nfs-common kubectl helm pwgen
 
 # Install k-alias Kubernetes helper scripts
 git clone https://github.com/jaggedmountain/k-alias.git /tmp/k-alias


### PR DESCRIPTION
Pins 'foundry' Keycloak user to GUID created during chart install. Links TopoMojo and Gameboard admin access to that GUID.

Fixes Helm upgrade issue by removing `openid` scopes from Keycloak client configs.