### PR TITLE
Update Helm apt repo location

### DIFF
--- a/foundry-appliance.pkr.hcl
+++ b/foundry-appliance.pkr.hcl
@@ -40,9 +40,8 @@ locals {
   cpus                 = 2
   disk_size_virtualbox = "40000"
   disk_size_proxmox    = "40G"
-  iso_url              = "https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso"
-  iso_file_proxmox     = "local:iso/ubuntu-24.04.2-live-server-amd64.iso"
-  iso_checksum         = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
+  iso_url              = "https://releases.ubuntu.com/noble/ubuntu-24.04.3-live-server-amd64.iso"
+  iso_checksum         = "sha256:c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b"
   memory               = 8192
   ssh_timeout          = "30m"
 }
@@ -73,7 +72,7 @@ source "proxmox-iso" "foundry-appliance" {
   boot_command = local.boot_command
   boot_iso {
     type         = "scsi"
-    iso_file     = local.iso_file_proxmox
+    iso_file     = "local:iso/${basename(local.iso_url)}"
     iso_checksum = local.iso_checksum
     unmount      = true
   }

--- a/foundry-appliance.pkr.hcl
+++ b/foundry-appliance.pkr.hcl
@@ -66,6 +66,10 @@ source "virtualbox-iso" "foundry-appliance" {
   ssh_timeout          = local.ssh_timeout
   ssh_username         = var.ssh_username
   vm_name              = "foundry-appliance-${var.appliance_version}"
+
+  vboxmanage = [
+    ["modifyvm", "{{ .Name }}", "--audio-enabled", "off"]
+  ]
 }
 
 source "proxmox-iso" "foundry-appliance" {

--- a/setup-appliance.sh
+++ b/setup-appliance.sh
@@ -28,8 +28,8 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key | gpg --dearm
 echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
 
 # Add Helm apt repo
-curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg >/dev/null
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
 
 # Upgrade existing packages to latest
 apt-get update


### PR DESCRIPTION
The apt repository for hosting Helm changed. This updates the appliance build to point to the new location.

More info:
https://github.com/helm/helm/issues/31082