### PR TITLE
Update deployment to use bitnamilegacy Docker images

### DIFF
--- a/foundry/charts/foundry/Chart.yaml
+++ b/foundry/charts/foundry/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 24.6.4
   - name: mkdocs-material
     repository: https://helm.cmusei.dev/charts
-    version: 0.2.7
+    version: 0.2.14
   - name: topomojo
     repository: https://helm.cmusei.dev/charts
     version: 0.5.2

--- a/foundry/charts/foundry/charts/gitea/values.yaml
+++ b/foundry/charts/foundry/charts/gitea/values.yaml
@@ -77,7 +77,7 @@ usePasswordFiles: true
 ##
 image:
   registry: docker.io
-  repository: bitnami/gitea
+  repository: bitnamilegacy/gitea
   tag: 1.23.8-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
@@ -750,7 +750,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
+    repository: bitnamilegacy/os-shell
     tag: 12-debian-12-r43
     digest: ""
     pullPolicy: IfNotPresent

--- a/foundry/charts/foundry/values.yaml
+++ b/foundry/charts/foundry/values.yaml
@@ -2,6 +2,8 @@ global:
   domain: foundry.local
   version: ""   # Appliance version overridden during Helm install on first boot
   infraHelmRelease: infra
+  security:
+    allowInsecureImages: true
 
 nfs-server-provisioner:
   persistence:
@@ -20,6 +22,8 @@ ingress-nginx:
     #5432: "{{ .Release.Namespace }}/postgresql:5432"
 
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     existingSecret: '{{ include "foundry.fullname" . }}'
   primary:
@@ -84,6 +88,8 @@ pgadmin4:
         runAsUser: 5050
 
 keycloak:
+  image:
+    repository: bitnamilegacy/keycloak
   auth:
     adminUser: "keycloak-admin"
     existingSecret: '{{ include "foundry.fullname" . }}-auth'


### PR DESCRIPTION
Will eventually migrate to non-Bitnami Helm charts or operators; this is a stopgap solution.