### PR TITLE
Crucible appliance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ helm dependency build crucible/charts/infra
 helm dependency build crucible/charts/crucible
 
 # On a deployed appliance, upgrade after editing values/templates
-helm upgrade -n crucible operators /home/crucible/charts/operators
-helm upgrade -n crucible infra /home/crucible/charts/infra
+helm upgrade -n crucible crucible-operators /home/crucible/charts/operators
+helm upgrade -n crucible crucible-infra /home/crucible/charts/infra
 helm upgrade -n crucible crucible /home/crucible/charts/crucible --set global.version=$(cat /etc/appliance_version)
 ```
 
@@ -61,7 +61,7 @@ helm upgrade -n crucible crucible /home/crucible/charts/crucible --set global.ve
 ### First Boot
 
 - **`configure-nic`** → `crucible/scripts/configure-nic.sh` — Detects the primary NIC and writes a netplan config.
-- **`install-crucible`** → `crucible/scripts/install-crucible.sh` — Installs K3s, creates the `crucible` namespace, installs cert-manager CRDs, then: (1) `helm install operators` (Keycloak Operator + CloudNative-PG), (2) `helm install infra` (waits for CA + CNPG Cluster), (3) `helm install crucible` (all applications).
+- **`install-crucible`** → `crucible/scripts/install-crucible.sh` — Installs K3s, creates the `crucible` namespace, installs cert-manager CRDs, then: (1) `helm install crucible-operators` (Keycloak Operator + CloudNative-PG), (2) `helm install crucible-infra` (waits for CA + CNPG Cluster), (3) `helm install crucible` (all applications).
 
 ### Helm Charts
 
@@ -69,15 +69,15 @@ helm upgrade -n crucible crucible /home/crucible/charts/crucible --set global.ve
 
 **`crucible/charts/infra`** — Wraps the upstream [sei/crucible-infra](https://github.com/cmu-sei/helm-charts/tree/main/charts/crucible-infra) chart. It provides:
 
-- CNPG PostgreSQL `Cluster` with auto-provisioned per-app databases and users (each app gets its own user via CNPG-managed secrets `infra-db-{name}`)
+- CNPG PostgreSQL `Cluster` with auto-provisioned per-app databases and users (each app gets its own user via CNPG-managed secrets `crucible-infra-db-{name}`)
 - ingress-nginx (all apps path-routed under `crucible.local`)
 - NFS server provisioner + PVCs for TopoMojo, Gameboard, Caster
 - pgAdmin at `/pgadmin`
 
 Local additions on top of the upstream chart:
 
-- cert-manager with a self-signed CA chain (`infra-selfsigned` → `infra-ca` → `infra-issuer` → `crucible-cert`) — keeps the appliance working offline
-- Gitea admin password Secret (`infra-gitea-admin`)
+- cert-manager with a self-signed CA chain (`crucible-infra-selfsigned` → `crucible-infra-ca` → `crucible-infra-issuer` → `crucible-cert`) — keeps the appliance working offline
+- Gitea admin password Secret (`crucible-infra-gitea-admin`)
 
 **`crucible/charts/crucible`** — Wraps three subcharts:
 
@@ -117,7 +117,7 @@ crucible/
     operators/               # Wraps sei/crucible-operators (Keycloak + CNPG operators)
     infra/                   # Wraps sei/crucible-infra + local cert-manager CA chain
       templates/
-        secret.yaml          # Gitea admin password (infra-gitea-admin)
+        secret.yaml          # Gitea admin password (crucible-infra-gitea-admin)
         cert-manager.yaml    # Self-signed CA chain and crucible-cert certificate
     crucible/                # Wraps sei/crucible-apps + Gitea + MkDocs
       charts/gitea/          # Local Bitnami Gitea subchart

--- a/crucible/charts/crucible/Chart.lock
+++ b/crucible/charts/crucible/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: crucible
+- name: crucible-apps
   repository: https://helm.cmusei.dev/charts
-  version: 0.1.3
+  version: 0.2.1
 - name: gitea
   repository: ""
   version: 3.2.8
 - name: mkdocs-material
   repository: https://helm.cmusei.dev/charts
   version: 0.2.15
-digest: sha256:4ad44c564e9e2ac7d683d06e7119616b6f8a05cf1b93cdbc907179aa72950ef0
-generated: "2026-03-13T03:57:39.589917727Z"
+digest: sha256:d6540de38c406c22b25fcbdaaa9730696e26d22a2ea2ede145bc1bdb394abc26
+generated: "2026-05-08T12:23:39.79617041Z"

--- a/crucible/charts/crucible/Chart.lock
+++ b/crucible/charts/crucible/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: crucible-apps
   repository: https://helm.cmusei.dev/charts
-  version: 0.2.1
+  version: 0.2.2
 - name: gitea
   repository: ""
   version: 3.2.8
 - name: mkdocs-material
   repository: https://helm.cmusei.dev/charts
   version: 0.2.15
-digest: sha256:d6540de38c406c22b25fcbdaaa9730696e26d22a2ea2ede145bc1bdb394abc26
-generated: "2026-05-08T12:23:39.79617041Z"
+digest: sha256:08002cd76988ca4f0ec29a909174d3e8a043e390aaff566a2acd5f2211d9f1cf
+generated: "2026-05-08T17:05:00.836974717Z"

--- a/crucible/charts/crucible/Chart.yaml
+++ b/crucible/charts/crucible/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.0.0
 dependencies:
   - name: crucible-apps
     repository: https://helm.cmusei.dev/charts
-    version: 0.2.1
+    version: 0.2.2
 
   - name: gitea
     version: 3.2.8

--- a/crucible/charts/crucible/templates/job.yaml
+++ b/crucible/charts/crucible/templates/job.yaml
@@ -20,7 +20,7 @@ spec:
         - name: ca-cert
           secret:
             defaultMode: 420
-            secretName: infra-ca
+            secretName: crucible-infra-ca
       containers:
         - name: gitea-cli
           image: {{ include "crucible-local.gitea.image" . }}
@@ -42,7 +42,7 @@ spec:
             - name: GITEA_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: infra-gitea-admin
+                  name: crucible-infra-gitea-admin
                   key: admin-password
             - name: OIDC_CLIENT_ID
               value: gitea-client
@@ -95,7 +95,7 @@ spec:
             - name: GITEA_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: infra-gitea-admin
+                  name: crucible-infra-gitea-admin
                   key: admin-password
           volumeMounts:
             - name: mkdocs
@@ -120,7 +120,7 @@ spec:
             defaultMode: 0755
         - name: crucible-ca-cert
           secret:
-            secretName: infra-ca
+            secretName: crucible-infra-ca
             items:
             - key: ca.crt
               path: ca.crt

--- a/crucible/charts/crucible/values.yaml
+++ b/crucible/charts/crucible/values.yaml
@@ -37,9 +37,9 @@ crucible-apps:
             return 302 $scheme://$host/keycloak/admin/crucible/console/;
           }
     externalDatabase:
-      host: infra-postgresql-rw
+      host: crucible-infra-postgresql-rw
       database: keycloak
-      existingSecret: infra-db-keycloak
+      existingSecret: crucible-infra-db-keycloak
       existingSecretUserKey: username
       existingSecretPasswordKey: password
 
@@ -47,9 +47,9 @@ crucible-apps:
     enabled: true
     alloy-api:
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: alloy
-        existingSecret: infra-db-alloy
+        existingSecret: crucible-infra-db-alloy
       resourceOwnerAuthorization:
         userName: crucible
         password: crucible
@@ -72,9 +72,9 @@ crucible-apps:
     blueprint-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: blueprint
-        existingSecret: infra-db-blueprint
+        existingSecret: crucible-infra-db-blueprint
       resourceOwnerAuthorization:
         userName: crucible
         password: crucible
@@ -100,9 +100,9 @@ crucible-apps:
     caster-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: caster
-        existingSecret: infra-db-caster
+        existingSecret: crucible-infra-db-caster
       client:
         userName: crucible
         password: crucible
@@ -128,9 +128,9 @@ crucible-apps:
     cite-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: cite
-        existingSecret: infra-db-cite
+        existingSecret: crucible-infra-db-cite
       ingress:
         className: nginx
         tls:
@@ -153,9 +153,9 @@ crucible-apps:
     gallery-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: gallery
-        existingSecret: infra-db-gallery
+        existingSecret: crucible-infra-db-gallery
       ingress:
         className: nginx
         tls:
@@ -178,9 +178,9 @@ crucible-apps:
     gameboard-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: gameboard
-        existingSecret: infra-db-gameboard
+        existingSecret: crucible-infra-db-gameboard
       ingress:
         className: nginx
         tls:
@@ -206,9 +206,9 @@ crucible-apps:
     player-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: player
-        existingSecret: infra-db-player
+        existingSecret: crucible-infra-db-player
       ingress:
         className: nginx
         tls:
@@ -228,9 +228,9 @@ crucible-apps:
     vm-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: player_vm
-        existingSecret: infra-db-player-vm
+        existingSecret: crucible-infra-db-player-vm
       ingress:
         className: nginx
         tls:
@@ -257,9 +257,9 @@ crucible-apps:
     steamfitter-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: steamfitter
-        existingSecret: infra-db-steamfitter
+        existingSecret: crucible-infra-db-steamfitter
       resourceOwnerAuthorization:
         userName: crucible
         password: crucible
@@ -285,9 +285,9 @@ crucible-apps:
     topomojo-api:
       certificateMap: crucible-ca-cert
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: topomojo
-        existingSecret: infra-db-topomojo
+        existingSecret: crucible-infra-db-topomojo
       ingress:
         className: nginx
         tls:
@@ -332,10 +332,10 @@ crucible-apps:
       site:
         url: "https://{{ .Values.global.domain }}"
       database:
-        host: infra-postgresql-rw
+        host: crucible-infra-postgresql-rw
         name: moodle
         user: moodle
-        existingSecret: infra-db-moodle
+        existingSecret: crucible-infra-db-moodle
         existingSecretUserKey: username
         existingSecretPasswordKey: password
       oidc:
@@ -349,18 +349,8 @@ crucible-apps:
     extraEnvVars:
       - name: SSL_CERT_FILE
         value: /opt/sei/certs/ca.crt
-      - name: SSL_CERT_DIR
-        value: /opt/sei/certs
       - name: CURL_CA_BUNDLE
         value: /opt/sei/certs/ca.crt
-    extraVolumes:
-      - name: crucible-ca-cert
-        configMap:
-          name: crucible-ca-cert
-    extraVolumeMounts:
-      - name: crucible-ca-cert
-        mountPath: /opt/sei/certs
-        readOnly: true
     ingress:
       hostname: "{{ .Values.global.domain }}"
       path: /
@@ -374,13 +364,16 @@ crucible-apps:
 # Gitea - Git server at /gitea
 # ---------------------------------------------------------------------------
 gitea:
+  global:
+    security:
+      allowInsecureImages: true
   adminUsername: crucible
   adminEmail: administrator@crucible.local
   appName: Crucible Gitea
   rootURL: "https://{{ .Values.global.domain }}/gitea"
   updateStrategy:
     type: Recreate
-  existingSecret: infra-gitea-admin
+  existingSecret: crucible-infra-gitea-admin
   extraEnvVars:
     - name: BITNAMI_EXTRA_CA_CERTIFICATES
       value: /etc/ssl/certs/ca-cert.crt
@@ -388,7 +381,7 @@ gitea:
   extraVolumes:
     - name: ca-cert
       secret:
-        secretName: infra-ca
+        secretName: crucible-infra-ca
   extraVolumeMounts:
     - name: ca-cert
       mountPath: /etc/ssl/certs/ca-cert.crt
@@ -414,10 +407,10 @@ gitea:
   postgresql:
     enabled: false
   externalDatabase:
-    host: infra-postgresql-rw
+    host: crucible-infra-postgresql-rw
     user: gitea
     database: gitea
-    existingSecret: infra-db-gitea
+    existingSecret: crucible-infra-db-gitea
     existingSecretPasswordKey: password
 
 # ---------------------------------------------------------------------------

--- a/crucible/charts/infra/Chart.lock
+++ b/crucible/charts/infra/Chart.lock
@@ -2,14 +2,8 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.20.0
-- name: nfs-server-provisioner
-  repository: https://kvaps.github.io/charts
-  version: 1.8.0
-- name: ingress-nginx
-  repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.15.0
-- name: postgres
-  repository: https://self-hosters-by-night.github.io/helm-charts
-  version: 0.14.2
-digest: sha256:4f2e96d45217621a837f6ffb5fdf133d8f91dd4be39e06dbb5a8907f6ca17845
-generated: "2026-03-13T03:57:45.489091112Z"
+- name: crucible-infra
+  repository: https://helm.cmusei.dev/charts
+  version: 0.1.0
+digest: sha256:33010533cec5463f4620772042aa1df613a797da58e51ef634ae53fa5783fbfd
+generated: "2026-05-08T12:23:52.437149307Z"

--- a/crucible/charts/operators/Chart.lock
+++ b/crucible/charts/operators/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: crucible-operators
+  repository: https://helm.cmusei.dev/charts
+  version: 0.1.0
+digest: sha256:3439b9630191310971179aab1ba2dbfb2ac4740eb3d3f82267dd674a92a5cc13
+generated: "2026-05-08T12:24:03.85696831Z"

--- a/crucible/scripts/install-crucible.sh
+++ b/crucible/scripts/install-crucible.sh
@@ -63,21 +63,21 @@ $RUN_AS_USER kubectl config set-context --current --namespace=crucible
 $RUN_AS_USER kubectl apply --validate=false -f https://github.com/cert-manager/cert-manager/releases/download/$CERT_MANAGER_VERSION/cert-manager.crds.yaml
 
 # 1. Install operators chart (Keycloak Operator + CloudNative-PG) cluster-wide
-$RUN_AS_USER helm install operators $CHARTS_DIR/operators --wait
+$RUN_AS_USER helm install crucible-operators $CHARTS_DIR/operators --wait
 
 # Wait for operator CRDs and pods to be ready
 $RUN_AS_USER timeout 300 bash -c 'while ! kubectl get crd keycloaks.k8s.keycloak.org &>/dev/null; do echo "Waiting for Keycloak CRDs..."; sleep 5; done'
 $RUN_AS_USER timeout 300 bash -c 'while ! kubectl get crd clusters.postgresql.cnpg.io &>/dev/null; do echo "Waiting for CNPG CRDs..."; sleep 5; done'
 
 # 2. Install infra chart (cert-manager CA chain, CNPG PostgreSQL, ingress, NFS, pgAdmin)
-$RUN_AS_USER helm install infra $CHARTS_DIR/infra --wait
+$RUN_AS_USER helm install crucible-infra $CHARTS_DIR/infra --wait
 
 # Wait for CA secret and PostgreSQL cluster to be ready
-$RUN_AS_USER timeout 300 bash -c 'while ! kubectl get secret infra-ca &>/dev/null; do echo "Waiting for infra-ca secret..."; sleep 5; done'
-$RUN_AS_USER timeout 600 bash -c 'while [ "$(kubectl get cluster infra-postgresql -o jsonpath="{.status.readyInstances}" 2>/dev/null)" != "1" ]; do echo "Waiting for PostgreSQL cluster..."; sleep 10; done'
+$RUN_AS_USER timeout 300 bash -c 'while ! kubectl get secret crucible-infra-ca &>/dev/null; do echo "Waiting for crucible-infra-ca secret..."; sleep 5; done'
+$RUN_AS_USER timeout 600 bash -c 'while [ "$(kubectl get cluster crucible-infra-postgresql -o jsonpath="{.status.readyInstances}" 2>/dev/null)" != "1" ]; do echo "Waiting for PostgreSQL cluster..."; sleep 10; done'
 
-# Create CA cert ConfigMap from infra-ca secret (upstream chart certificateMap requires a ConfigMap)
-$RUN_AS_USER kubectl get secret infra-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+# Create CA cert ConfigMap from crucible-infra-ca secret (upstream chart certificateMap requires a ConfigMap)
+$RUN_AS_USER kubectl get secret crucible-infra-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
 $RUN_AS_USER kubectl create configmap crucible-ca-cert --from-file=ca.crt=/tmp/ca.crt
 rm -f /tmp/ca.crt
 


### PR DESCRIPTION
Overhaul of the appliance to build for the full Crucible framework. This renames the appliance "Crucible Appliance" to reflect that the full Crucible Framework is available. 

## Summary of changes: 

1. Adds a devcontainer for ease of development/building. 
2. Adds a new Proxmox build option for building from the dev container or other environments where a Proxmox VM may not be able to reach the Packer HTTP server for cloud-init - delivers cloud init data via ISO instead. 
3. Uses new charts ([Crucible Apps](https://github.com/cmu-sei/helm-charts/tree/main/charts/crucible-apps), [Crucible Operators](https://github.com/cmu-sei/helm-charts/tree/main/charts/crucible-operators), and [Crucible Infra](https://github.com/cmu-sei/helm-charts/tree/main/charts/crucible-infra)) to manage deployment of the Crucible stack
4. Updates k3s version